### PR TITLE
Docs: clarify metadata indexing workflow and dataset terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Benchmarking framework for **functional microRNA target prediction**.
 
 FuNmiRBench provides:
 
-- Standardized metadata for >50 GEO functional miRNA perturbation datasets  (maybe even more)
+- Standardized metadata for >50 functional miRNA perturbation RNA-seq datasets (currently sourced from GEO)
 - A unified Python API to:
-  - list and filter experiments by miRNA, cell line, perturbation type, tissue, GEO accession  
+  - list and filter datasets by miRNA, cell line, perturbation type, tissue, and GEO accession
   - load differential expression tables (edgeR outputs) into pandas  
   - summarize the available datasets
 - A foundation for baseline models and future dashboards (visualization & evaluation)
@@ -42,11 +42,9 @@ FuNmiRBench/
 │       └── tool_name.tsv        # e.g. targetscan.tsv (not defined yet the structure)
 │
 ├── metadata/
-│   ├── datasets_core.json       # curated DIANA/Zenodo datasets
-│   ├── datasets_user.json       # user-registered datasets (optional)
-│   ├── datasets.json            # generated dataset index (built from TSV)
-│   ├── mirna_experiment_info.tsv  # curated input table (one row per dataset)
-│   └── predictions.json         # metadata about prediction files
+│   ├── README.md                 # explains metadata inputs/outputs
+│   ├── mirna_experiment_info.tsv # curated input table (one row per dataset)
+│   └── datasets.json             # generated dataset index (built from TSV)
 │
 ├── pipelines/
 │   └── geo/

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ FuNmiRBench/
 ├── metadata/
 │   ├── datasets_core.json       # curated DIANA/Zenodo datasets
 │   ├── datasets_user.json       # user-registered datasets (optional)
-│   ├── datasets.json            # combined view (core + user) - auto-built
-│   ├── mirna_experiment_info.tsv
+│   ├── datasets.json            # generated dataset index (built from TSV)
+│   ├── mirna_experiment_info.tsv  # curated input table (one row per dataset)
 │   └── predictions.json         # metadata about prediction files
 │
 ├── pipelines/
@@ -69,6 +69,15 @@ FuNmiRBench/
 └── tests/
     └── test_datasets.py, test_predictions.py, ...
 ```
+
+To regenerate `metadata/datasets.json` from the curated TSV:
+
+```bash
+python scripts/build_index.py
+```
+
+### !!! Planned additions (not yet in the repo): user-registered datasets, prediction indices, and additional ingestion pipelines.
+
 📊 Using the dataset API
 
 Basic loading:

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -1,0 +1,41 @@
+# Metadata
+
+FuNmiRBench separates **dataset metadata** (what datasets exist and where their DE tables live)
+from the **data files** themselves (which are not tracked by git).
+
+## Files in this folder
+
+### `mirna_experiment_info.tsv` (input / curated)
+Tab-separated table with one row per experiment/dataset.
+
+This file is treated as **authoritative input** and should not be modified by the pipeline.
+FuNmiRBench uses it to build a machine-readable index (`datasets.json`).
+
+Key columns:
+- `mirna_name`: miRNA identifier (e.g. `hsa-miR-375-3p`)
+- `mirna_sequence`: mature miRNA sequence
+- `article_pubmed_id`: PubMed URL or ID
+- `tested_cell_line`: cell line (optional)
+- `treatment`: free-text description (optional)
+- `tissue`: tissue (optional)
+- `experiment_type`: `OE`, `KD`, or `KO`
+- `gse_url`: GEO record URL (source information)
+- `de_table_path`: filename of the processed DE table (TSV) for this experiment
+
+### `datasets.json` (generated index)
+JSON list of dataset entries produced by `scripts/build_index.py`.
+
+Each entry includes:
+- `id`: FuNmiRBench dataset ID (e.g. `"001"`)
+- `geo_accession`: GEO accession extracted from `gse_url` (e.g. `GSE210778`)
+- `miRNA`, `miRNA_sequence`, `cell_line`, `tissue`, `perturbation`, `treatment`, `pubmed_id`, `gse_url`
+- `data_path`: path to the processed DE TSV file (relative path string)
+
+> Note: `data_path` is a pointer. The DE TSV files are **not stored in this repository**.
+
+## Regenerating `datasets.json`
+
+From the repository root:
+
+```bash
+python scripts/build_index.py

--- a/pipelines/geo/README.md
+++ b/pipelines/geo/README.md
@@ -1,7 +1,9 @@
-# GEO processing pipeline (placeholder)
+# GEO ingestion pipeline (GEO → processed DE tables)
 
 This directory will contain the pipeline that converts raw GEO data
 into differential expression (DE) tables compatible with FuNmiRBench.
+
+> Note: the processed directory can be configured when building `datasets.json` via `scripts/build_index.py --processed-dir ...`.
 
 Expected output format: TSV files with columns:
 

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -1,3 +1,4 @@
+import argparse
 import csv
 import json
 import pathlib
@@ -5,9 +6,10 @@ import urllib.parse
 from typing import List, Dict, Optional
 
 
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-INFO_TSV = ROOT / "metadata" / "mirna_experiment_info.tsv"
-OUT_JSON = ROOT / "metadata" / "datasets.json"
+DEFAULT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+DEFAULT_INFO_TSV = DEFAULT_ROOT / "metadata" / "mirna_experiment_info.tsv"
+DEFAULT_OUT_JSON = DEFAULT_ROOT / "metadata" / "datasets.json"
+DEFAULT_PROCESSED_DIR = pathlib.Path("data") / "processed_GEO"
 
 
 def map_experiment_type(experiment_type_raw: str) -> Optional[str]:
@@ -43,10 +45,67 @@ def extract_geo_accession(gse_url: str) -> Optional[str]:
     return gse_url.rstrip("/").split("/")[-1]
 
 
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Build metadata/datasets.json from metadata/mirna_experiment_info.tsv"
+    )
+    p.add_argument(
+        "--info-tsv",
+        type=pathlib.Path,
+        default=DEFAULT_INFO_TSV,
+        help="Input TSV with experiment metadata (default: metadata/mirna_experiment_info.tsv).",
+    )
+    p.add_argument(
+        "--out-json",
+        type=pathlib.Path,
+        default=DEFAULT_OUT_JSON,
+        help="Output JSON path (default: metadata/datasets.json).",
+    )
+    p.add_argument(
+        "--processed-dir",
+        type=pathlib.Path,
+        default=DEFAULT_PROCESSED_DIR,
+        help="Base directory for processed experiment files, used to form data_path "
+             "(default: data/processed_GEO).",
+    )
+    p.add_argument(
+        "--root",
+        type=pathlib.Path,
+        default=DEFAULT_ROOT,
+        help="Project root directory used to resolve default paths (default: repo root).",
+    )
+    return p.parse_args()
+
+
 def main() -> None:
+    args = parse_args()
+
+    # Resolve defaults relative to root if caller set --root explicitly.
+    root = args.root.expanduser().resolve()
+
+    info_tsv: pathlib.Path = args.info_tsv
+    out_json: pathlib.Path = args.out_json
+    processed_dir: pathlib.Path = args.processed_dir
+
+    # If user passed relative paths, interpret them relative to root
+    if not info_tsv.is_absolute():
+        info_tsv = root / info_tsv
+    if not out_json.is_absolute():
+        out_json = root / out_json
+
+    # processed_dir is written into JSON as a relative path by default;
+    # keep it relative unless user explicitly provides an absolute path.
+    if processed_dir.is_absolute():
+        processed_dir_rel = processed_dir
+    else:
+        processed_dir_rel = processed_dir
+
     datasets: List[Dict] = []
 
-    with INFO_TSV.open("r", encoding="utf-8") as f:
+    if not info_tsv.exists():
+        raise FileNotFoundError(f"Input TSV not found: {info_tsv}")
+
+    with info_tsv.open("r", encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter="\t")
 
         for i, row in enumerate(reader, start=1):
@@ -62,6 +121,9 @@ def main() -> None:
             geo_accession = extract_geo_accession(gse_url)
             de_table_path = row["de_table_path"].strip()
 
+            # Build the data_path in a configurable way (default keeps old layout).
+            data_path = (processed_dir_rel / de_table_path).as_posix()
+
             entry = {
                 "id": f"{i:03d}",
                 "geo_accession": geo_accession,
@@ -75,15 +137,16 @@ def main() -> None:
                 "treatment": treatment,
                 "pubmed_id": pubmed_id,
                 "gse_url": gse_url,
-                "data_path": f"data/processed_GEO/{de_table_path}"
+                "data_path": data_path,
             }
 
             datasets.append(entry)
 
-    with OUT_JSON.open("w", encoding="utf-8") as f:
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    with out_json.open("w", encoding="utf-8") as f:
         json.dump(datasets, f, indent=2)
 
-    print(f"Wrote {len(datasets)} entries to {OUT_JSON}")
+    print(f"Wrote {len(datasets)} entries to {out_json}")
 
 
 if __name__ == "__main__":

--- a/src/funmirbench/datasets.py
+++ b/src/funmirbench/datasets.py
@@ -9,7 +9,7 @@ This module:
 """
 
 from __future__ import annotations
-
+import os
 import json
 import pathlib
 from dataclasses import dataclass
@@ -17,8 +17,33 @@ from typing import List, Optional, Dict, Any
 
 
 # Project root (FuNmiRBench/)
-ROOT = pathlib.Path(__file__).resolve().parents[2]
-DATASETS_JSON = ROOT / "metadata" / "datasets.json"
+# Defaults (can be overridden via function args or env vars)
+DEFAULT_ROOT = pathlib.Path(__file__).resolve().parents[2]
+DEFAULT_DATASETS_JSON = DEFAULT_ROOT / "metadata" / "datasets.json"
+
+
+def get_root(root: Optional[pathlib.Path] = None) -> pathlib.Path:
+    """Resolve project root, allowing override via arg or FUNMIRBENCH_ROOT."""
+    if root is not None:
+        return root
+    env_root = os.getenv("FUNMIRBENCH_ROOT")
+    if env_root:
+        return pathlib.Path(env_root).expanduser().resolve()
+    return DEFAULT_ROOT
+
+
+def get_datasets_json(
+    *,
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
+) -> pathlib.Path:
+    """Resolve datasets.json path, allowing override via arg or FUNMIRBENCH_DATASETS_JSON."""
+    if datasets_json is not None:
+        return datasets_json
+    env_path = os.getenv("FUNMIRBENCH_DATASETS_JSON")
+    if env_path:
+        return pathlib.Path(env_path).expanduser().resolve()
+    return get_root(root) / "metadata" / "datasets.json"
 
 
 @dataclass
@@ -38,34 +63,44 @@ class DatasetMeta:
     pubmed_id: Optional[str]
     gse_url: Optional[str]
     data_path: str
+    root: pathlib.Path = DEFAULT_ROOT  # resolved root for this dataset
 
     @property
     def full_path(self) -> pathlib.Path:
         """Absolute path to the TSV file on disk."""
-        return ROOT / self.data_path
+        return self.root / self.data_path
 
-
-def _load_raw_metadata() -> List[Dict[str, Any]]:
+def _load_raw_metadata(
+    *,
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
+) -> List[Dict[str, Any]]:
     """Load raw JSON objects from metadata/datasets.json."""
-    if not DATASETS_JSON.exists():
-        raise FileNotFoundError(f"Metadata file not found: {DATASETS_JSON}")
+    path = get_datasets_json(root=root, datasets_json=datasets_json)
+    if not path.exists():
+        raise FileNotFoundError(f"Metadata file not found: {path}")
 
-    with DATASETS_JSON.open("r", encoding="utf-8") as f:
+    with path.open("r", encoding="utf-8") as f:
         data = json.load(f)
 
     if not isinstance(data, list):
-        raise ValueError(f"Expected a list in {DATASETS_JSON}, got {type(data)}")
+        raise ValueError(f"Expected a list in {path}, got {type(data)}")
 
     return data
 
 
-def load_metadata() -> List[DatasetMeta]:
+def load_metadata(
+    *,
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
+) -> List[DatasetMeta]:
     """
     Return a list of DatasetMeta objects for all experiments.
 
     This is the main entry point to inspect available datasets.
     """
-    raw = _load_raw_metadata()
+    resolved_root = get_root(root)
+    raw = _load_raw_metadata(root=resolved_root, datasets_json=datasets_json)
     metas: List[DatasetMeta] = []
 
     for entry in raw:
@@ -84,6 +119,7 @@ def load_metadata() -> List[DatasetMeta]:
                 pubmed_id=entry.get("pubmed_id"),
                 gse_url=entry.get("gse_url"),
                 data_path=entry["data_path"],
+                root=resolved_root,
             )
         )
 
@@ -106,6 +142,8 @@ def list_datasets(
     perturbation: Optional[str] = None,
     tissue: Optional[str] = None,
     geo_accession: Optional[str] = None,
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
 ) -> List[DatasetMeta]:
     """
     Return a list of DatasetMeta filtered by the given criteria.
@@ -115,7 +153,7 @@ def list_datasets(
     - list_datasets(perturbation="overexpression")
     - list_datasets(miRNA="hsa-miR-124-3p", cell_line="HeLa")
     """
-    metas = load_metadata()
+    metas = load_metadata(root=root, datasets_json=datasets_json)
     results: List[DatasetMeta] = []
 
     for m in metas:
@@ -134,15 +172,26 @@ def list_datasets(
     return results
 
 
-def get_dataset(id: str) -> Optional[DatasetMeta]:
+def get_dataset(
+    id: str,
+    *,
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
+) -> Optional[DatasetMeta]:
     """Return the DatasetMeta with the given ID, or None if not found."""
-    for m in load_metadata():
+    for m in load_metadata(root=root, datasets_json=datasets_json):
         if m.id == id:
             return m
     return None
 
 
-def load_dataset(id: str, *, sep: str = "\t"):
+def load_dataset(
+    id: str,
+    *,
+    sep: str = "\t",
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
+):
     """
     Load a single dataset's TSV as a pandas DataFrame.
 
@@ -157,7 +206,7 @@ def load_dataset(id: str, *, sep: str = "\t"):
     -------
     pandas.DataFrame
     """
-    meta = get_dataset(id)
+    meta = get_dataset(id, root=root, datasets_json=datasets_json)
     if meta is None:
         raise ValueError(f"No dataset with id {id!r}")
 
@@ -184,6 +233,8 @@ def load_all_datasets(
     tissue: Optional[str] = None,
     geo_accession: Optional[str] = None,
     sep: str = "\t",
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
 ):
     """
     Load and concatenate multiple datasets into a single DataFrame.
@@ -205,6 +256,8 @@ def load_all_datasets(
         perturbation=perturbation,
         tissue=tissue,
         geo_accession=geo_accession,
+        root=root,
+        datasets_json=datasets_json
     )
 
     frames = []
@@ -325,9 +378,13 @@ def group_by_geo() -> Dict[str, List[DatasetMeta]]:
     return grouped
 
 
-def list_ids() -> List[str]:
-    """Return a sorted list of all dataset IDs."""
-    metas = load_metadata()
+def list_ids(
+    *,
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
+) -> List[str]:
+    # return a short list of dataset ids.
+    metas = load_metadata(root=root, datasets_json=datasets_json)
     return sorted(m.id for m in metas)
 
 
@@ -335,7 +392,11 @@ def list_datasets_by_cell_line(cell_line: str) -> List[DatasetMeta]:
     """Return all datasets associated with a specific cell line."""
     return list_datasets(cell_line=cell_line)
 
-def summarize_datasets() -> List[Dict[str, Any]]:
+def summarize_datasets(
+    *,
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
+) -> List[Dict[str, Any]]:
     """
     Return a list of lightweight summaries, one per dataset.
 
@@ -348,7 +409,7 @@ def summarize_datasets() -> List[Dict[str, Any]]:
     - geo_accession
     - pubmed_id
     """
-    metas = load_metadata()
+    metas = load_metadata(root=root, datasets_json=datasets_json)
     summaries: List[Dict[str, Any]] = []
 
     for m in metas:


### PR DESCRIPTION
> **Note:** This PR is based on PR1 (configurable paths). If PR1 changes, I’ll rebase accordingly.

## Summary
This PR clarifies FuNmiRBench’s metadata workflow and improves documentation consistency.
It makes explicit which metadata files are curated inputs vs generated outputs, and
it updates terminology so “dataset/experiment” is the core concept (GEO is treated as a source).

## What changed
- Added `metadata/README.md` documenting:
  - `mirna_experiment_info.tsv` as the curated input table (source of truth)
  - `datasets.json` as the generated dataset index
  - how to regenerate `datasets.json` with `scripts/build_index.py`
  - how `--processed-dir` affects `data_path` values
- Updated top-level `README.md`:
  - terminology cleanup: dataset/experiment as primary concept; GEO as current source
  - project structure section updated to reflect current repository contents
  - added a short note on regenerating `metadata/datasets.json`

## Why
- Reduce confusion about metadata “ground truth” and avoid divergence between files.
- Make the repo read as a general benchmarking framework (not GEO-specific), while
  keeping GEO-specific fields where relevant (e.g., GEO accession).

## How to test
No functional behavior changes are intended in this PR. As a quick sanity check:

```bash
python scripts/build_index.py