### PR TITLE
Add predictions registry + mock prediction generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ miniconda3/
 data/processed_GEO/*
 data/raw_GEO/*
 
+# testing
+data/predictions/mock/canonical/mock.tsv
+

--- a/README.md
+++ b/README.md
@@ -36,10 +36,8 @@ export PYTHONPATH="$PWD/src:$PYTHONPATH"
 ```
 FuNmiRBench/
 ├── data/
-│   ├── processed_GEO/           # DE tables (not in git)
-│   ├── raw_GEO/                 # raw / counts / etc (not in git)
-│   └── predictions/             # precomputed tool scores (not in git)
-│       └── tool_name.tsv        # e.g. targetscan.tsv (not defined yet the structure)
+│   ├── README.md                 # explains expected local data layout (not tracked)
+│   └── predictions/              # placeholder (not tracked)
 │
 ├── metadata/
 │   ├── README.md                 # explains metadata inputs/outputs
@@ -74,7 +72,7 @@ To regenerate `metadata/datasets.json` from the curated TSV:
 python scripts/build_index.py
 ```
 
-### !!! Planned additions (not yet in the repo): user-registered datasets, prediction indices, and additional ingestion pipelines.
+Planned additions: user-registered datasets, prediction indices, and additional ingestion pipelines.
 
 📊 Using the dataset API
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Benchmarking framework for **functional microRNA target prediction**.
 
 FuNmiRBench provides:
 
-- Standardized metadata for >50 GEO functional miRNA perturbation datasets  (maybe even more)
+- Standardized metadata for >50 functional miRNA perturbation RNA-seq datasets (currently sourced from GEO)
 - A unified Python API to:
-  - list and filter experiments by miRNA, cell line, perturbation type, tissue, GEO accession  
+  - list and filter datasets by miRNA, cell line, perturbation type, tissue, and GEO accession
   - load differential expression tables (edgeR outputs) into pandas  
   - summarize the available datasets
 - A foundation for baseline models and future dashboards (visualization & evaluation)
@@ -42,11 +42,9 @@ FuNmiRBench/
 │       └── tool_name.tsv        # e.g. targetscan.tsv (not defined yet the structure)
 │
 ├── metadata/
-│   ├── datasets_core.json       # curated DIANA/Zenodo datasets
-│   ├── datasets_user.json       # user-registered datasets (optional)
-│   ├── datasets.json            # generated dataset index (built from TSV)
-│   ├── mirna_experiment_info.tsv  # curated input table (one row per dataset)
-│   └── predictions.json         # metadata about prediction files
+│   ├── README.md                 # explains metadata inputs/outputs
+│   ├── mirna_experiment_info.tsv # curated input table (one row per dataset)
+│   └── datasets.json             # generated dataset index (built from TSV)
 │
 ├── pipelines/
 │   └── geo/

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ FuNmiRBench/
 ├── metadata/
 │   ├── datasets_core.json       # curated DIANA/Zenodo datasets
 │   ├── datasets_user.json       # user-registered datasets (optional)
-│   ├── datasets.json            # combined view (core + user) - auto-built
-│   ├── mirna_experiment_info.tsv
+│   ├── datasets.json            # generated dataset index (built from TSV)
+│   ├── mirna_experiment_info.tsv  # curated input table (one row per dataset)
 │   └── predictions.json         # metadata about prediction files
 │
 ├── pipelines/
@@ -69,6 +69,15 @@ FuNmiRBench/
 └── tests/
     └── test_datasets.py, test_predictions.py, ...
 ```
+
+To regenerate `metadata/datasets.json` from the curated TSV:
+
+```bash
+python scripts/build_index.py
+```
+
+### !!! Planned additions (not yet in the repo): user-registered datasets, prediction indices, and additional ingestion pipelines.
+
 📊 Using the dataset API
 
 Basic loading:

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -1,0 +1,41 @@
+# Metadata
+
+FuNmiRBench separates **dataset metadata** (what datasets exist and where their DE tables live)
+from the **data files** themselves (which are not tracked by git).
+
+## Files in this folder
+
+### `mirna_experiment_info.tsv` (input / curated)
+Tab-separated table with one row per experiment/dataset.
+
+This file is treated as **authoritative input** and should not be modified by the pipeline.
+FuNmiRBench uses it to build a machine-readable index (`datasets.json`).
+
+Key columns:
+- `mirna_name`: miRNA identifier (e.g. `hsa-miR-375-3p`)
+- `mirna_sequence`: mature miRNA sequence
+- `article_pubmed_id`: PubMed URL or ID
+- `tested_cell_line`: cell line (optional)
+- `treatment`: free-text description (optional)
+- `tissue`: tissue (optional)
+- `experiment_type`: `OE`, `KD`, or `KO`
+- `gse_url`: GEO record URL (source information)
+- `de_table_path`: filename of the processed DE table (TSV) for this experiment
+
+### `datasets.json` (generated index)
+JSON list of dataset entries produced by `scripts/build_index.py`.
+
+Each entry includes:
+- `id`: FuNmiRBench dataset ID (e.g. `"001"`)
+- `geo_accession`: GEO accession extracted from `gse_url` (e.g. `GSE210778`)
+- `miRNA`, `miRNA_sequence`, `cell_line`, `tissue`, `perturbation`, `treatment`, `pubmed_id`, `gse_url`
+- `data_path`: path to the processed DE TSV file (relative path string)
+
+> Note: `data_path` is a pointer. The DE TSV files are **not stored in this repository**.
+
+## Regenerating `datasets.json`
+
+From the repository root:
+
+```bash
+python scripts/build_index.py

--- a/metadata/predictions.json
+++ b/metadata/predictions.json
@@ -1,0 +1,12 @@
+[
+  {
+    "tool_id": "mock",
+    "display_name": "Mock predictor",
+    "organism": "Homo sapiens",
+    "score_direction": "higher_is_stronger",
+    "score_range": "0-1",
+    "input_id_type": "ensembl_gene",
+    "canonical_id_type": "ensembl_gene",
+    "canonical_tsv_path": "data/predictions/mock/canonical/mock.tsv"
+  }
+]

--- a/metadata/predictions_info.tsv
+++ b/metadata/predictions_info.tsv
@@ -1,0 +1,2 @@
+tool_id	display_name	organism	score_direction	score_range	input_id_type	canonical_id_type	canonical_tsv_path
+mock	Mock predictor	Homo sapiens	higher_is_stronger	0-1	ensembl_gene	ensembl_gene	data/predictions/mock/canonical/mock.tsv

--- a/pipelines/geo/README.md
+++ b/pipelines/geo/README.md
@@ -1,7 +1,9 @@
-# GEO processing pipeline (placeholder)
+# GEO ingestion pipeline (GEO → processed DE tables)
 
 This directory will contain the pipeline that converts raw GEO data
 into differential expression (DE) tables compatible with FuNmiRBench.
+
+> Note: the processed directory can be configured when building `datasets.json` via `scripts/build_index.py --processed-dir ...`.
 
 Expected output format: TSV files with columns:
 

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -1,3 +1,4 @@
+import argparse
 import csv
 import json
 import pathlib
@@ -5,9 +6,10 @@ import urllib.parse
 from typing import List, Dict, Optional
 
 
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-INFO_TSV = ROOT / "metadata" / "mirna_experiment_info.tsv"
-OUT_JSON = ROOT / "metadata" / "datasets.json"
+DEFAULT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+DEFAULT_INFO_TSV = DEFAULT_ROOT / "metadata" / "mirna_experiment_info.tsv"
+DEFAULT_OUT_JSON = DEFAULT_ROOT / "metadata" / "datasets.json"
+DEFAULT_PROCESSED_DIR = pathlib.Path("data") / "processed_GEO"
 
 
 def map_experiment_type(experiment_type_raw: str) -> Optional[str]:
@@ -43,10 +45,67 @@ def extract_geo_accession(gse_url: str) -> Optional[str]:
     return gse_url.rstrip("/").split("/")[-1]
 
 
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Build metadata/datasets.json from metadata/mirna_experiment_info.tsv"
+    )
+    p.add_argument(
+        "--info-tsv",
+        type=pathlib.Path,
+        default=DEFAULT_INFO_TSV,
+        help="Input TSV with experiment metadata (default: metadata/mirna_experiment_info.tsv).",
+    )
+    p.add_argument(
+        "--out-json",
+        type=pathlib.Path,
+        default=DEFAULT_OUT_JSON,
+        help="Output JSON path (default: metadata/datasets.json).",
+    )
+    p.add_argument(
+        "--processed-dir",
+        type=pathlib.Path,
+        default=DEFAULT_PROCESSED_DIR,
+        help="Base directory for processed experiment files, used to form data_path "
+             "(default: data/processed_GEO).",
+    )
+    p.add_argument(
+        "--root",
+        type=pathlib.Path,
+        default=DEFAULT_ROOT,
+        help="Project root directory used to resolve default paths (default: repo root).",
+    )
+    return p.parse_args()
+
+
 def main() -> None:
+    args = parse_args()
+
+    # Resolve defaults relative to root if caller set --root explicitly.
+    root = args.root.expanduser().resolve()
+
+    info_tsv: pathlib.Path = args.info_tsv
+    out_json: pathlib.Path = args.out_json
+    processed_dir: pathlib.Path = args.processed_dir
+
+    # If user passed relative paths, interpret them relative to root
+    if not info_tsv.is_absolute():
+        info_tsv = root / info_tsv
+    if not out_json.is_absolute():
+        out_json = root / out_json
+
+    # processed_dir is written into JSON as a relative path by default;
+    # keep it relative unless user explicitly provides an absolute path.
+    if processed_dir.is_absolute():
+        processed_dir_rel = processed_dir
+    else:
+        processed_dir_rel = processed_dir
+
     datasets: List[Dict] = []
 
-    with INFO_TSV.open("r", encoding="utf-8") as f:
+    if not info_tsv.exists():
+        raise FileNotFoundError(f"Input TSV not found: {info_tsv}")
+
+    with info_tsv.open("r", encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter="\t")
 
         for i, row in enumerate(reader, start=1):
@@ -62,6 +121,9 @@ def main() -> None:
             geo_accession = extract_geo_accession(gse_url)
             de_table_path = row["de_table_path"].strip()
 
+            # Build the data_path in a configurable way (default keeps old layout).
+            data_path = (processed_dir_rel / de_table_path).as_posix()
+
             entry = {
                 "id": f"{i:03d}",
                 "geo_accession": geo_accession,
@@ -75,15 +137,16 @@ def main() -> None:
                 "treatment": treatment,
                 "pubmed_id": pubmed_id,
                 "gse_url": gse_url,
-                "data_path": f"data/processed_GEO/{de_table_path}"
+                "data_path": data_path,
             }
 
             datasets.append(entry)
 
-    with OUT_JSON.open("w", encoding="utf-8") as f:
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    with out_json.open("w", encoding="utf-8") as f:
         json.dump(datasets, f, indent=2)
 
-    print(f"Wrote {len(datasets)} entries to {OUT_JSON}")
+    print(f"Wrote {len(datasets)} entries to {out_json}")
 
 
 if __name__ == "__main__":

--- a/scripts/build_predictions.py
+++ b/scripts/build_predictions.py
@@ -1,0 +1,153 @@
+import argparse
+import hashlib
+import math
+import pathlib
+from typing import Dict, Tuple, Set
+
+
+DEFAULT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+DEFAULT_OUT = DEFAULT_ROOT / "data" / "predictions" / "mock" / "canonical" / "mock.tsv"
+DEFAULT_DATASETS_JSON = DEFAULT_ROOT / "metadata" / "datasets.json"
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Build canonical prediction files (mock for now).")
+    p.add_argument(
+        "--tool",
+        required=True,
+        choices=["mock"],
+        help="Which tool to build (currently: mock).",
+    )
+    p.add_argument(
+        "--out",
+        type=pathlib.Path,
+        default=DEFAULT_OUT,
+        help="Output TSV path (default: data/predictions/mock/canonical/mock.tsv).",
+    )
+    p.add_argument(
+        "--datasets-json",
+        type=pathlib.Path,
+        default=DEFAULT_DATASETS_JSON,
+        help="Path to datasets metadata JSON (default: metadata/datasets.json).",
+    )
+    p.add_argument(
+        "--root",
+        type=pathlib.Path,
+        default=DEFAULT_ROOT,
+        help="Project root directory used to resolve relative paths (default: repo root).",
+    )
+    p.add_argument(
+        "--max-genes-per-mirna",
+        type=int,
+        default=5000,
+        help="Limit genes per miRNA (default: 5000).",
+    )
+    return p.parse_args()
+
+
+def stable_hash_float(s: str) -> float:
+    """Deterministic float in [0,1)."""
+    h = hashlib.sha256(s.encode("utf-8")).hexdigest()
+    v = int(h[:12], 16)  # 48-bit chunk
+    return (v % 1_000_000) / 1_000_000.0
+
+
+def logistic(x: float) -> float:
+    return 1.0 / (1.0 + math.exp(-x))
+
+
+def build_mock_scores(
+    datasets_json: pathlib.Path,
+    *,
+    max_genes_per_mirna: int,
+) -> Dict[Tuple[str, str], float]:
+    """
+    Build a global (mirna, gene_id) -> score table.
+
+    This mimics a real predictor: one score file per tool, independent of dataset_id.
+    Scores are deterministic probabilities in [0,1] where higher = "stronger targeting".
+    """
+    try:
+        import pandas as pd  # type: ignore
+    except ImportError as exc:
+        raise ImportError("pandas is required to build mock predictions.") from exc
+
+    # Import loader from your src-layout; run with PYTHONPATH="$PWD/src"
+    from funmirbench.datasets import load_metadata  # type: ignore
+
+    metas = load_metadata(datasets_json=datasets_json)
+
+    genes_by_mirna: Dict[str, Set[str]] = {}
+
+    for m in metas:
+        path = m.full_path
+        if not path.exists():
+            # Data not present locally; skip
+            continue
+
+        df = pd.read_csv(path, sep=r"\s+", engine="python")
+        df.columns = [c.strip() for c in df.columns]
+
+        if "gene_name" not in df.columns:
+            raise ValueError(f"{path} missing required column 'gene_name'")
+
+        gene_ids = set(df["gene_name"].dropna().astype(str).tolist())
+        genes_by_mirna.setdefault(m.miRNA, set()).update(gene_ids)
+
+    scores: Dict[Tuple[str, str], float] = {}
+
+    for mirna, gene_set in genes_by_mirna.items():
+        gene_list = sorted(gene_set)
+
+        # Stable subsampling if needed
+        if max_genes_per_mirna and len(gene_list) > max_genes_per_mirna:
+            gene_list = sorted(
+                gene_list,
+                key=lambda g: stable_hash_float(mirna + "::" + g),
+            )[:max_genes_per_mirna]
+
+        for gene_id in gene_list:
+            # base in [0,1)
+            base = stable_hash_float(mirna + "::" + gene_id)
+            # map to probability via logistic; center to avoid all ~0.5
+            score = logistic((base - 0.5) * 6.0)
+
+            scores[(mirna, gene_id)] = float(score)
+
+    return scores
+
+
+def write_tsv(scores: Dict[Tuple[str, str], float], out_path: pathlib.Path) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as f:
+        f.write("mirna\tgene_id\tscore\n")
+        for (mirna, gene_id), score in sorted(scores.items()):
+            f.write(f"{mirna}\t{gene_id}\t{score:.6f}\n")
+
+
+def main() -> None:
+    args = parse_args()
+    root = args.root.expanduser().resolve()
+
+    datasets_json = args.datasets_json
+    out_path = args.out
+
+    if not datasets_json.is_absolute():
+        datasets_json = root / datasets_json
+    if not out_path.is_absolute():
+        out_path = root / out_path
+
+    if args.tool == "mock":
+        scores = build_mock_scores(
+            datasets_json,
+            max_genes_per_mirna=args.max_genes_per_mirna,
+        )
+        write_tsv(scores, out_path)
+        print(f"Wrote {len(scores)} rows to {out_path}")
+        return
+
+    raise ValueError(f"Unknown tool: {args.tool}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_predictions_index.py
+++ b/scripts/build_predictions_index.py
@@ -1,0 +1,118 @@
+import argparse
+import csv
+import json
+import pathlib
+from typing import Dict, List
+
+
+DEFAULT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+DEFAULT_INFO_TSV = DEFAULT_ROOT / "metadata" / "predictions_info.tsv"
+DEFAULT_OUT_JSON = DEFAULT_ROOT / "metadata" / "predictions.json"
+
+
+REQUIRED_COLUMNS = [
+    "tool_id",
+    "display_name",
+    "organism",
+    "score_direction",
+    "score_range",
+    "input_id_type",
+    "canonical_id_type",
+    "canonical_tsv_path",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Build metadata/predictions.json from metadata/predictions_info.tsv"
+    )
+    p.add_argument(
+        "--info-tsv",
+        type=pathlib.Path,
+        default=DEFAULT_INFO_TSV,
+        help="Input TSV with prediction resources (default: metadata/predictions_info.tsv).",
+    )
+    p.add_argument(
+        "--out-json",
+        type=pathlib.Path,
+        default=DEFAULT_OUT_JSON,
+        help="Output JSON path (default: metadata/predictions.json).",
+    )
+    p.add_argument(
+        "--root",
+        type=pathlib.Path,
+        default=DEFAULT_ROOT,
+        help="Project root directory used to resolve relative paths (default: repo root).",
+    )
+    return p.parse_args()
+
+
+def _validate_row(row: Dict[str, str], row_num: int) -> None:
+    missing = [c for c in REQUIRED_COLUMNS if c not in row or row[c].strip() == ""]
+    if missing:
+        raise ValueError(f"Row {row_num} is missing required columns: {missing}")
+
+    # Minimal validation for score_range like "0-1" or "0-100"
+    score_range = row["score_range"].strip()
+    if "-" not in score_range:
+        raise ValueError(
+            f"Row {row_num} has invalid score_range {score_range!r}; expected like '0-1' or '0-100'."
+        )
+
+
+def main() -> None:
+    args = parse_args()
+
+    root = args.root.expanduser().resolve()
+
+    info_tsv = args.info_tsv
+    out_json = args.out_json
+
+    if not info_tsv.is_absolute():
+        info_tsv = root / info_tsv
+    if not out_json.is_absolute():
+        out_json = root / out_json
+
+    if not info_tsv.exists():
+        raise FileNotFoundError(f"Input TSV not found: {info_tsv}")
+
+    entries: List[Dict[str, str]] = []
+    seen_tool_ids = set()
+
+    with info_tsv.open("r", encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        if reader.fieldnames is None:
+            raise ValueError(f"TSV has no header row: {info_tsv}")
+
+        for i, row in enumerate(reader, start=2):  # header is line 1
+            _validate_row(row, i)
+
+            tool_id = row["tool_id"].strip()
+            if tool_id in seen_tool_ids:
+                raise ValueError(f"Duplicate tool_id {tool_id!r} at row {i}")
+            seen_tool_ids.add(tool_id)
+
+            entry = {
+                "tool_id": tool_id,
+                "display_name": row["display_name"].strip(),
+                "organism": row["organism"].strip(),
+                "score_direction": row["score_direction"].strip(),
+                "score_range": row["score_range"].strip(),
+                "input_id_type": row["input_id_type"].strip(),
+                "canonical_id_type": row["canonical_id_type"].strip(),
+                "canonical_tsv_path": row["canonical_tsv_path"].strip(),
+            }
+            entries.append(entry)
+
+    # Stable output order
+    entries = sorted(entries, key=lambda d: d["tool_id"])
+
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    with out_json.open("w", encoding="utf-8") as f:
+        json.dump(entries, f, indent=2)
+
+    print(f"Wrote {len(entries)} entries to {out_json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/funmirbench/datasets.py
+++ b/src/funmirbench/datasets.py
@@ -9,7 +9,7 @@ This module:
 """
 
 from __future__ import annotations
-
+import os
 import json
 import pathlib
 from dataclasses import dataclass
@@ -17,8 +17,33 @@ from typing import List, Optional, Dict, Any
 
 
 # Project root (FuNmiRBench/)
-ROOT = pathlib.Path(__file__).resolve().parents[2]
-DATASETS_JSON = ROOT / "metadata" / "datasets.json"
+# Defaults (can be overridden via function args or env vars)
+DEFAULT_ROOT = pathlib.Path(__file__).resolve().parents[2]
+DEFAULT_DATASETS_JSON = DEFAULT_ROOT / "metadata" / "datasets.json"
+
+
+def get_root(root: Optional[pathlib.Path] = None) -> pathlib.Path:
+    """Resolve project root, allowing override via arg or FUNMIRBENCH_ROOT."""
+    if root is not None:
+        return root
+    env_root = os.getenv("FUNMIRBENCH_ROOT")
+    if env_root:
+        return pathlib.Path(env_root).expanduser().resolve()
+    return DEFAULT_ROOT
+
+
+def get_datasets_json(
+    *,
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
+) -> pathlib.Path:
+    """Resolve datasets.json path, allowing override via arg or FUNMIRBENCH_DATASETS_JSON."""
+    if datasets_json is not None:
+        return datasets_json
+    env_path = os.getenv("FUNMIRBENCH_DATASETS_JSON")
+    if env_path:
+        return pathlib.Path(env_path).expanduser().resolve()
+    return get_root(root) / "metadata" / "datasets.json"
 
 
 @dataclass
@@ -38,34 +63,44 @@ class DatasetMeta:
     pubmed_id: Optional[str]
     gse_url: Optional[str]
     data_path: str
+    root: pathlib.Path = DEFAULT_ROOT  # resolved root for this dataset
 
     @property
     def full_path(self) -> pathlib.Path:
         """Absolute path to the TSV file on disk."""
-        return ROOT / self.data_path
+        return self.root / self.data_path
 
-
-def _load_raw_metadata() -> List[Dict[str, Any]]:
+def _load_raw_metadata(
+    *,
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
+) -> List[Dict[str, Any]]:
     """Load raw JSON objects from metadata/datasets.json."""
-    if not DATASETS_JSON.exists():
-        raise FileNotFoundError(f"Metadata file not found: {DATASETS_JSON}")
+    path = get_datasets_json(root=root, datasets_json=datasets_json)
+    if not path.exists():
+        raise FileNotFoundError(f"Metadata file not found: {path}")
 
-    with DATASETS_JSON.open("r", encoding="utf-8") as f:
+    with path.open("r", encoding="utf-8") as f:
         data = json.load(f)
 
     if not isinstance(data, list):
-        raise ValueError(f"Expected a list in {DATASETS_JSON}, got {type(data)}")
+        raise ValueError(f"Expected a list in {path}, got {type(data)}")
 
     return data
 
 
-def load_metadata() -> List[DatasetMeta]:
+def load_metadata(
+    *,
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
+) -> List[DatasetMeta]:
     """
     Return a list of DatasetMeta objects for all experiments.
 
     This is the main entry point to inspect available datasets.
     """
-    raw = _load_raw_metadata()
+    resolved_root = get_root(root)
+    raw = _load_raw_metadata(root=resolved_root, datasets_json=datasets_json)
     metas: List[DatasetMeta] = []
 
     for entry in raw:
@@ -84,6 +119,7 @@ def load_metadata() -> List[DatasetMeta]:
                 pubmed_id=entry.get("pubmed_id"),
                 gse_url=entry.get("gse_url"),
                 data_path=entry["data_path"],
+                root=resolved_root,
             )
         )
 
@@ -106,6 +142,8 @@ def list_datasets(
     perturbation: Optional[str] = None,
     tissue: Optional[str] = None,
     geo_accession: Optional[str] = None,
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
 ) -> List[DatasetMeta]:
     """
     Return a list of DatasetMeta filtered by the given criteria.
@@ -115,7 +153,7 @@ def list_datasets(
     - list_datasets(perturbation="overexpression")
     - list_datasets(miRNA="hsa-miR-124-3p", cell_line="HeLa")
     """
-    metas = load_metadata()
+    metas = load_metadata(root=root, datasets_json=datasets_json)
     results: List[DatasetMeta] = []
 
     for m in metas:
@@ -134,15 +172,26 @@ def list_datasets(
     return results
 
 
-def get_dataset(id: str) -> Optional[DatasetMeta]:
+def get_dataset(
+    id: str,
+    *,
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
+) -> Optional[DatasetMeta]:
     """Return the DatasetMeta with the given ID, or None if not found."""
-    for m in load_metadata():
+    for m in load_metadata(root=root, datasets_json=datasets_json):
         if m.id == id:
             return m
     return None
 
 
-def load_dataset(id: str, *, sep: str = "\t"):
+def load_dataset(
+    id: str,
+    *,
+    sep: str = "\t",
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
+):
     """
     Load a single dataset's TSV as a pandas DataFrame.
 
@@ -157,7 +206,7 @@ def load_dataset(id: str, *, sep: str = "\t"):
     -------
     pandas.DataFrame
     """
-    meta = get_dataset(id)
+    meta = get_dataset(id, root=root, datasets_json=datasets_json)
     if meta is None:
         raise ValueError(f"No dataset with id {id!r}")
 
@@ -184,6 +233,8 @@ def load_all_datasets(
     tissue: Optional[str] = None,
     geo_accession: Optional[str] = None,
     sep: str = "\t",
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
 ):
     """
     Load and concatenate multiple datasets into a single DataFrame.
@@ -205,6 +256,8 @@ def load_all_datasets(
         perturbation=perturbation,
         tissue=tissue,
         geo_accession=geo_accession,
+        root=root,
+        datasets_json=datasets_json
     )
 
     frames = []
@@ -325,9 +378,13 @@ def group_by_geo() -> Dict[str, List[DatasetMeta]]:
     return grouped
 
 
-def list_ids() -> List[str]:
-    """Return a sorted list of all dataset IDs."""
-    metas = load_metadata()
+def list_ids(
+    *,
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
+) -> List[str]:
+    # return a short list of dataset ids.
+    metas = load_metadata(root=root, datasets_json=datasets_json)
     return sorted(m.id for m in metas)
 
 
@@ -335,7 +392,11 @@ def list_datasets_by_cell_line(cell_line: str) -> List[DatasetMeta]:
     """Return all datasets associated with a specific cell line."""
     return list_datasets(cell_line=cell_line)
 
-def summarize_datasets() -> List[Dict[str, Any]]:
+def summarize_datasets(
+    *,
+    root: Optional[pathlib.Path] = None,
+    datasets_json: Optional[pathlib.Path] = None,
+) -> List[Dict[str, Any]]:
     """
     Return a list of lightweight summaries, one per dataset.
 
@@ -348,7 +409,7 @@ def summarize_datasets() -> List[Dict[str, Any]]:
     - geo_accession
     - pubmed_id
     """
-    metas = load_metadata()
+    metas = load_metadata(root=root, datasets_json=datasets_json)
     summaries: List[Dict[str, Any]] = []
 
     for m in metas:


### PR DESCRIPTION
## Summary
This PR introduces the initial predictions “mock”.

It mirrors the dataset metadata design:
- curated TSV is the source of truth
- JSON index is generated from TSV
- prediction score files are generated and not committed

## What’s included
- `metadata/predictions_info.tsv` (source of truth)
- `scripts/build_predictions_index.py` (builds `metadata/predictions.json`)
- `scripts/build_predictions.py` (generates a mock canonical prediction file)

## Output conventions
- Canonical predictions are written to:
  `data/predictions/<tool_id>/<tool_id>_canonical.tsv`

Example for mock:
- `data/predictions/mock/mock_canonical.tsv`

## How to test
```bash
python scripts/build_predictions_index.py

PYTHONPATH="$PWD/src" python scripts/build_predictions.py --tool mock
