### PR TITLE
Strengthen experiment validation

### DIFF
--- a/funmirbench/validate_experiments.py
+++ b/funmirbench/validate_experiments.py
@@ -1,23 +1,57 @@
-"""Validate that experiment DE tables referenced by metadata exist and are readable."""
+"""Validate that experiment DE tables referenced by metadata are benchmark-ready."""
 
 import argparse
 import logging
+import math
 import pathlib
-from typing import Iterable
+import re
+import sys
+from dataclasses import dataclass
 
 import pandas as pd
 
-from funmirbench.de_table import read_de_table
+from funmirbench.de_table import find_gene_id_column, read_de_table
 from funmirbench.logger import parse_log_level, setup_logging
 
 
 logger = logging.getLogger(__name__)
+REGISTRY_ISSUE_ID = "<registry>"
+REQUIRED_REGISTRY_COLUMNS = (
+    "id",
+    "mirna_name",
+    "organism",
+    "experiment_type",
+    "de_table_path",
+)
+REQUIRED_DE_COLUMNS = ("gene_id", "logFC", "FDR")
+VALID_PERTURBATIONS = {"OE", "KO", "KD"}
+MAX_LOGGED_ISSUES = 20
+_ENSEMBL_GENE_ID = re.compile(r"^ENS[A-Z]*G\d+(?:\.\d+)?$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    dataset_id: str
+    check: str
+    message: str
+    path: str = ""
+
+
+@dataclass(frozen=True)
+class ValidationSummary:
+    total: int
+    files_present: int
+    benchmark_ready: int
+    issues: list[ValidationIssue]
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
 
 
 def resolve_de_table_path(
     de_table_path: str | pathlib.Path,
     *,
-    experiments_tsv: pathlib.Path,
     root: pathlib.Path | None = None,
 ) -> pathlib.Path:
     path = pathlib.Path(de_table_path)
@@ -27,64 +61,386 @@ def resolve_de_table_path(
     if root is not None:
         return (root / path).resolve()
 
-    candidates: Iterable[pathlib.Path] = (
-        pathlib.Path.cwd(),
-        experiments_tsv.parent,
-    )
-    for candidate_root in candidates:
-        candidate = (candidate_root / path).resolve()
-        if candidate.exists():
-            return candidate
     return (pathlib.Path.cwd() / path).resolve()
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Validate experiment DE table files.")
+def _text(value) -> str:
+    if pd.isna(value):
+        return ""
+    return str(value).strip()
+
+
+def _duplicate_values(values: pd.Series) -> list[str]:
+    normalized = values.map(_text)
+    normalized = normalized[normalized != ""]
+    return sorted(normalized[normalized.duplicated()].unique().tolist())
+
+
+def _normalize_de_table(path: pathlib.Path) -> pd.DataFrame:
+    de = read_de_table(path)
+    gene_src = find_gene_id_column(de)
+    if gene_src == "__index__":
+        de = de.copy()
+        de.insert(0, "gene_id", de.index.astype(str))
+    else:
+        de = de.rename(columns={gene_src: "gene_id"})
+    return de
+
+
+def _finite_numeric(series: pd.Series) -> tuple[pd.Series, pd.Series]:
+    numeric = pd.to_numeric(series, errors="coerce")
+    finite = numeric.map(lambda value: pd.notna(value) and math.isfinite(float(value)))
+    return numeric, finite
+
+
+def _expected_effect(logfc: pd.Series, perturbation: str) -> pd.Series:
+    perturbation = perturbation.upper()
+    if perturbation == "OE":
+        return -logfc
+    return logfc
+
+
+def _validate_de_table(
+    *,
+    dataset_id: str,
+    perturbation: str,
+    path: pathlib.Path,
+    fdr_threshold: float,
+    abs_logfc_threshold: float,
+) -> list[ValidationIssue]:
+    issues = []
+    try:
+        de = _normalize_de_table(path)
+    except Exception as exc:
+        return [
+            ValidationIssue(
+                dataset_id,
+                "readable_de_table",
+                f"DE table could not be read: {exc}",
+                str(path),
+            )
+        ]
+
+    missing = [column for column in REQUIRED_DE_COLUMNS if column not in de.columns]
+    if missing:
+        return [
+            ValidationIssue(
+                dataset_id,
+                "required_de_columns",
+                f"DE table is missing required columns: {missing}",
+                str(path),
+            )
+        ]
+
+    if de.empty:
+        issues.append(
+            ValidationIssue(
+                dataset_id,
+                "nonempty_de_table",
+                "DE table has no rows.",
+                str(path),
+            )
+        )
+        return issues
+
+    gene_ids = de["gene_id"].map(_text)
+    blank_gene_count = int((gene_ids == "").sum())
+    if blank_gene_count:
+        issues.append(
+            ValidationIssue(
+                dataset_id,
+                "gene_id_values",
+                f"DE table has {blank_gene_count} blank gene_id value(s).",
+                str(path),
+            )
+        )
+
+    duplicate_gene_count = int(gene_ids[gene_ids != ""].duplicated().sum())
+    if duplicate_gene_count:
+        issues.append(
+            ValidationIssue(
+                dataset_id,
+                "duplicate_gene_ids",
+                f"DE table has {duplicate_gene_count} duplicate gene_id value(s).",
+                str(path),
+            )
+        )
+
+    non_ensembl_count = int(
+        (~gene_ids[gene_ids != ""].str.match(_ENSEMBL_GENE_ID)).sum()
+    )
+    if non_ensembl_count:
+        issues.append(
+            ValidationIssue(
+                dataset_id,
+                "ensembl_gene_ids",
+                f"DE table has {non_ensembl_count} non-Ensembl gene_id value(s).",
+                str(path),
+            )
+        )
+
+    logfc, valid_logfc = _finite_numeric(de["logFC"])
+    invalid_logfc_count = int((~valid_logfc).sum())
+    if invalid_logfc_count:
+        issues.append(
+            ValidationIssue(
+                dataset_id,
+                "numeric_logfc",
+                f"DE table has {invalid_logfc_count} non-numeric or non-finite logFC value(s).",
+                str(path),
+            )
+        )
+
+    fdr, valid_fdr = _finite_numeric(de["FDR"])
+    invalid_fdr_count = int((~valid_fdr).sum())
+    if invalid_fdr_count:
+        issues.append(
+            ValidationIssue(
+                dataset_id,
+                "numeric_fdr",
+                f"DE table has {invalid_fdr_count} non-numeric or non-finite FDR value(s).",
+                str(path),
+            )
+        )
+
+    valid_fdr_values = fdr[valid_fdr]
+    out_of_range_fdr_count = int(
+        ((valid_fdr_values <= 0.0) | (valid_fdr_values > 1.0)).sum()
+    )
+    if out_of_range_fdr_count:
+        issues.append(
+            ValidationIssue(
+                dataset_id,
+                "fdr_range",
+                f"DE table has {out_of_range_fdr_count} FDR value(s) outside (0, 1].",
+                str(path),
+            )
+        )
+
+    if issues:
+        return issues
+
+    effect = _expected_effect(logfc.astype(float), perturbation)
+    positives = int((
+        (fdr.astype(float) < float(fdr_threshold))
+        & (effect > float(abs_logfc_threshold))
+    ).sum())
+    negatives = int(len(de) - positives)
+    if positives == 0:
+        issues.append(
+            ValidationIssue(
+                dataset_id,
+                "ground_truth_classes",
+                (
+                    "DE table has no positive genes under "
+                    f"FDR<{fdr_threshold} and effect>{abs_logfc_threshold}."
+                ),
+                str(path),
+            )
+        )
+    if negatives == 0:
+        issues.append(
+            ValidationIssue(
+                dataset_id,
+                "ground_truth_classes",
+                (
+                    "DE table has no negative genes under "
+                    f"FDR<{fdr_threshold} and effect>{abs_logfc_threshold}."
+                ),
+                str(path),
+            )
+        )
+    return issues
+
+
+def _registry_issues(df: pd.DataFrame) -> list[ValidationIssue]:
+    issues = []
+    missing_columns = [
+        column for column in REQUIRED_REGISTRY_COLUMNS if column not in df.columns
+    ]
+    if missing_columns:
+        issues.append(
+            ValidationIssue(
+                REGISTRY_ISSUE_ID,
+                "registry_columns",
+                f"Experiment registry is missing required columns: {missing_columns}",
+            )
+        )
+        return issues
+
+    duplicate_ids = _duplicate_values(df["id"])
+    if duplicate_ids:
+        issues.append(
+            ValidationIssue(
+                REGISTRY_ISSUE_ID,
+                "duplicate_dataset_ids",
+                f"Experiment registry has duplicate id value(s): {duplicate_ids}",
+            )
+        )
+
+    duplicate_paths = _duplicate_values(df["de_table_path"])
+    if duplicate_paths:
+        issues.append(
+            ValidationIssue(
+                REGISTRY_ISSUE_ID,
+                "duplicate_de_table_paths",
+                f"Experiment registry has duplicate de_table_path value(s): {duplicate_paths}",
+            )
+        )
+    return issues
+
+
+def _validate_registry_row(row: pd.Series) -> list[ValidationIssue]:
+    dataset_id = _text(row.get("id")) or REGISTRY_ISSUE_ID
+    issues = []
+    for column in REQUIRED_REGISTRY_COLUMNS:
+        if not _text(row.get(column)):
+            issues.append(
+                ValidationIssue(
+                    dataset_id,
+                    "required_registry_value",
+                    f"Registry row is missing required value {column!r}.",
+                )
+            )
+
+    perturbation = _text(row.get("experiment_type")).upper()
+    if perturbation and perturbation not in VALID_PERTURBATIONS:
+        issues.append(
+            ValidationIssue(
+                dataset_id,
+                "experiment_type",
+                (
+                    f"Unsupported experiment_type {row.get('experiment_type')!r}; "
+                    f"expected one of {sorted(VALID_PERTURBATIONS)}."
+                ),
+            )
+        )
+    return issues
+
+
+def validate_experiments(
+    experiments_tsv: str | pathlib.Path,
+    *,
+    root: pathlib.Path | None = None,
+    fdr_threshold: float = 0.05,
+    abs_logfc_threshold: float = 1.0,
+) -> ValidationSummary:
+    experiments_tsv = pathlib.Path(experiments_tsv).expanduser().resolve()
+    root = pathlib.Path(root).expanduser().resolve() if root is not None else None
+    df = pd.read_csv(experiments_tsv, sep="\t", dtype=str).fillna("")
+
+    issues = _registry_issues(df)
+    if any(issue.check == "registry_columns" for issue in issues):
+        return ValidationSummary(
+            total=int(len(df)),
+            files_present=0,
+            benchmark_ready=0,
+            issues=issues,
+        )
+
+    files_present = 0
+    invalid_dataset_ids = set()
+    for _, row in df.iterrows():
+        dataset_id = _text(row.get("id")) or REGISTRY_ISSUE_ID
+        row_issues = _validate_registry_row(row)
+        issues.extend(row_issues)
+
+        path_value = _text(row.get("de_table_path"))
+        if not path_value:
+            invalid_dataset_ids.add(dataset_id)
+            continue
+
+        path = resolve_de_table_path(path_value, root=root)
+        if not path.is_file():
+            issues.append(
+                ValidationIssue(
+                    dataset_id,
+                    "de_table_file",
+                    f"DE table path does not point to a file: {path}",
+                    str(path),
+                )
+            )
+            invalid_dataset_ids.add(dataset_id)
+            continue
+
+        files_present += 1
+        perturbation = _text(row.get("experiment_type")).upper()
+        if perturbation in VALID_PERTURBATIONS:
+            table_issues = _validate_de_table(
+                dataset_id=dataset_id,
+                perturbation=perturbation,
+                path=path,
+                fdr_threshold=fdr_threshold,
+                abs_logfc_threshold=abs_logfc_threshold,
+            )
+            issues.extend(table_issues)
+            if table_issues:
+                invalid_dataset_ids.add(dataset_id)
+        if row_issues:
+            invalid_dataset_ids.add(dataset_id)
+
+    if any(
+        issue.check in {"duplicate_dataset_ids", "duplicate_de_table_paths"}
+        for issue in issues
+    ):
+        invalid_dataset_ids.update(_text(value) for value in df["id"] if _text(value))
+
+    return ValidationSummary(
+        total=int(len(df)),
+        files_present=files_present,
+        benchmark_ready=max(0, int(len(df)) - len(invalid_dataset_ids)),
+        issues=issues,
+    )
+
+
+def log_validation_summary(summary: ValidationSummary) -> None:
+    logger.info("Datasets in metadata:      %s", summary.total)
+    logger.info("Files present:             %s", summary.files_present)
+    logger.info("Benchmark-ready datasets:  %s", summary.benchmark_ready)
+    if summary.ok:
+        return
+
+    logger.error("Validation issues:         %s", len(summary.issues))
+    for issue in summary.issues[:MAX_LOGGED_ISSUES]:
+        location = f" ({issue.path})" if issue.path else ""
+        logger.error(
+            "  - %s [%s]: %s%s",
+            issue.dataset_id,
+            issue.check,
+            issue.message,
+            location,
+        )
+    remaining = len(summary.issues) - MAX_LOGGED_ISSUES
+    if remaining > 0:
+        logger.error("  ... %s more issue(s)", remaining)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate experiment DE table files are benchmark-ready."
+    )
     parser.add_argument("--experiments-tsv", type=pathlib.Path, required=True)
     parser.add_argument("--root", type=pathlib.Path, default=None)
-    parser.add_argument("--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
-    args = parser.parse_args()
+    parser.add_argument("--fdr-threshold", type=float, default=0.05)
+    parser.add_argument("--abs-logfc-threshold", type=float, default=1.0)
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+    )
+    args = parser.parse_args(argv)
 
     setup_logging(parse_log_level(args.log_level))
 
-    experiments_tsv = args.experiments_tsv.resolve()
-    root = args.root.resolve() if args.root is not None else None
-    df = pd.read_csv(experiments_tsv, sep="\t")
-
-    total = len(df)
-    present = 0
-    readable = 0
-    missing = []
-    unreadable = []
-
-    for _, row in df.iterrows():
-        path = resolve_de_table_path(
-            row["de_table_path"],
-            experiments_tsv=experiments_tsv,
-            root=root,
-        )
-        if not path.exists():
-            missing.append((row["id"], str(path)))
-            continue
-        present += 1
-        try:
-            read_de_table(path)
-            readable += 1
-        except Exception as exc:
-            unreadable.append((row["id"], str(exc)))
-
-    logger.info("Datasets in metadata: %s", total)
-    logger.info("Files present:        %s", present)
-    logger.info("Readable DE tables:   %s", readable)
-    if missing:
-        logger.warning("Missing files:        %s", len(missing))
-        for dataset_id, path in missing[:20]:
-            logger.warning("  - %s: %s", dataset_id, path)
-    if unreadable:
-        logger.error("Unreadable files:     %s", len(unreadable))
-        for dataset_id, message in unreadable[:20]:
-            logger.error("  - %s: %s", dataset_id, message)
+    summary = validate_experiments(
+        args.experiments_tsv,
+        root=args.root,
+        fdr_threshold=args.fdr_threshold,
+        abs_logfc_threshold=args.abs_logfc_threshold,
+    )
+    log_validation_summary(summary)
+    return 0 if summary.ok else 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/test_validate_experiments.py
+++ b/tests/test_validate_experiments.py
@@ -1,15 +1,58 @@
 """Tests for experiment validation helpers."""
 
-from pathlib import Path
+import subprocess
+import sys
 
-from funmirbench.validate_experiments import resolve_de_table_path
+import pandas as pd
+
+from funmirbench.validate_experiments import resolve_de_table_path, validate_experiments
+
+
+def _write(path, content):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _registry_row(de_table_path="data/experiments/processed/18745741/demo.tsv", **overrides):
+    row = {
+        "id": "T001",
+        "mirna_name": "hsa-miR-test",
+        "organism": "Homo sapiens",
+        "experiment_type": "OE",
+        "de_table_path": de_table_path,
+    }
+    row.update(overrides)
+    return row
+
+
+def _write_registry(tmp_path, rows):
+    experiments_tsv = tmp_path / "metadata" / "mirna_experiment_info.tsv"
+    experiments_tsv.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows).to_csv(experiments_tsv, sep="\t", index=False)
+    return experiments_tsv
+
+
+def _write_de_table(tmp_path, content):
+    de_table = tmp_path / "data" / "experiments" / "processed" / "18745741" / "demo.tsv"
+    _write(de_table, content)
+    return de_table
+
+
+def _valid_de_table():
+    return (
+        "gene_id\tlogFC\tFDR\n"
+        "ENSG00000000001\t-2.0\t0.01\n"
+        "ENSG00000000002\t0.2\t0.50\n"
+    )
+
+
+def _issue_checks(summary):
+    return {issue.check for issue in summary.issues}
 
 
 def test_resolve_de_table_path_prefers_repo_root_cwd(tmp_path, monkeypatch):
     repo_root = tmp_path
-    experiments_tsv = repo_root / "metadata" / "mirna_experiment_info.tsv"
-    experiments_tsv.parent.mkdir(parents=True)
-    experiments_tsv.write_text("id\tde_table_path\n", encoding="utf-8")
+    _write(repo_root / "metadata" / "mirna_experiment_info.tsv", "id\tde_table_path\n")
 
     de_table = repo_root / "data" / "experiments" / "processed" / "18745741" / "demo.tsv"
     de_table.parent.mkdir(parents=True)
@@ -17,28 +60,201 @@ def test_resolve_de_table_path_prefers_repo_root_cwd(tmp_path, monkeypatch):
 
     monkeypatch.chdir(repo_root)
 
-    resolved = resolve_de_table_path(
-        "data/experiments/processed/18745741/demo.tsv",
-        experiments_tsv=experiments_tsv,
-    )
+    resolved = resolve_de_table_path("data/experiments/processed/18745741/demo.tsv")
 
     assert resolved == de_table.resolve()
 
 
 def test_resolve_de_table_path_uses_explicit_root(tmp_path):
-    experiments_tsv = tmp_path / "metadata" / "mirna_experiment_info.tsv"
-    experiments_tsv.parent.mkdir(parents=True)
-    experiments_tsv.write_text("id\tde_table_path\n", encoding="utf-8")
-
     root = tmp_path / "repo"
+    _write(root / "metadata" / "mirna_experiment_info.tsv", "id\tde_table_path\n")
+
     de_table = root / "data" / "experiments" / "processed" / "18745741" / "demo.tsv"
     de_table.parent.mkdir(parents=True)
     de_table.write_text("gene_id\tlogFC\tFDR\n", encoding="utf-8")
 
     resolved = resolve_de_table_path(
-        Path("data/experiments/processed/18745741/demo.tsv"),
-        experiments_tsv=experiments_tsv,
+        "data/experiments/processed/18745741/demo.tsv",
         root=root,
     )
 
     assert resolved == de_table.resolve()
+
+
+def test_validate_experiments_accepts_benchmark_ready_table(tmp_path, monkeypatch):
+    experiments_tsv = _write_registry(tmp_path, [_registry_row()])
+    _write_de_table(tmp_path, _valid_de_table())
+    monkeypatch.chdir(tmp_path)
+
+    summary = validate_experiments(experiments_tsv)
+
+    assert summary.ok
+    assert summary.total == 1
+    assert summary.files_present == 1
+    assert summary.benchmark_ready == 1
+
+
+def test_validate_experiments_requires_registry_columns(tmp_path, monkeypatch):
+    experiments_tsv = _write_registry(
+        tmp_path,
+        [{"id": "T001", "de_table_path": "data/experiments/processed/18745741/demo.tsv"}],
+    )
+    monkeypatch.chdir(tmp_path)
+
+    summary = validate_experiments(experiments_tsv)
+
+    assert not summary.ok
+    assert _issue_checks(summary) == {"registry_columns"}
+
+
+def test_validate_experiments_rejects_duplicate_registry_values(tmp_path, monkeypatch):
+    experiments_tsv = _write_registry(
+        tmp_path,
+        [
+            _registry_row(id="T001"),
+            _registry_row(id="T001"),
+        ],
+    )
+    _write_de_table(tmp_path, _valid_de_table())
+    monkeypatch.chdir(tmp_path)
+
+    summary = validate_experiments(experiments_tsv)
+
+    assert not summary.ok
+    assert {"duplicate_dataset_ids", "duplicate_de_table_paths"} <= _issue_checks(summary)
+
+
+def test_validate_experiments_rejects_missing_de_table_file(tmp_path, monkeypatch):
+    experiments_tsv = _write_registry(tmp_path, [_registry_row()])
+    monkeypatch.chdir(tmp_path)
+
+    summary = validate_experiments(experiments_tsv)
+
+    assert not summary.ok
+    assert "de_table_file" in _issue_checks(summary)
+
+
+def test_validate_experiments_rejects_missing_required_de_columns(tmp_path, monkeypatch):
+    experiments_tsv = _write_registry(tmp_path, [_registry_row()])
+    _write_de_table(
+        tmp_path,
+        "gene_id\tlogFC\n"
+        "ENSG00000000001\t-2.0\n",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    summary = validate_experiments(experiments_tsv)
+
+    assert not summary.ok
+    assert "required_de_columns" in _issue_checks(summary)
+
+
+def test_validate_experiments_rejects_duplicate_blank_and_non_ensembl_gene_ids(tmp_path, monkeypatch):
+    experiments_tsv = _write_registry(tmp_path, [_registry_row()])
+    _write_de_table(
+        tmp_path,
+        "gene_id\tlogFC\tFDR\n"
+        "ENSG00000000001\t-2.0\t0.01\n"
+        "ENSG00000000001\t0.2\t0.50\n"
+        "\t0.3\t0.60\n"
+        "TP53\t0.4\t0.70\n",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    summary = validate_experiments(experiments_tsv)
+
+    assert not summary.ok
+    assert {"gene_id_values", "duplicate_gene_ids", "ensembl_gene_ids"} <= _issue_checks(summary)
+
+
+def test_validate_experiments_rejects_non_numeric_values(tmp_path, monkeypatch):
+    experiments_tsv = _write_registry(tmp_path, [_registry_row()])
+    _write_de_table(
+        tmp_path,
+        "gene_id\tlogFC\tFDR\n"
+        "ENSG00000000001\tbad\t0.01\n"
+        "ENSG00000000002\t0.2\tbad\n",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    summary = validate_experiments(experiments_tsv)
+
+    assert not summary.ok
+    assert {"numeric_logfc", "numeric_fdr"} <= _issue_checks(summary)
+
+
+def test_validate_experiments_rejects_fdr_outside_open_closed_unit_interval(tmp_path, monkeypatch):
+    experiments_tsv = _write_registry(tmp_path, [_registry_row()])
+    _write_de_table(
+        tmp_path,
+        "gene_id\tlogFC\tFDR\n"
+        "ENSG00000000001\t-2.0\t0\n"
+        "ENSG00000000002\t0.2\t1.20\n",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    summary = validate_experiments(experiments_tsv)
+
+    assert not summary.ok
+    assert "fdr_range" in _issue_checks(summary)
+
+
+def test_validate_experiments_rejects_invalid_perturbation(tmp_path, monkeypatch):
+    experiments_tsv = _write_registry(tmp_path, [_registry_row(experiment_type="ACTIVATION")])
+    _write_de_table(tmp_path, _valid_de_table())
+    monkeypatch.chdir(tmp_path)
+
+    summary = validate_experiments(experiments_tsv)
+
+    assert not summary.ok
+    assert "experiment_type" in _issue_checks(summary)
+
+
+def test_validate_experiments_requires_positive_and_negative_gt_classes(tmp_path, monkeypatch):
+    zero_positive_root = tmp_path / "zero_positive"
+    zero_positive_tsv = _write_registry(zero_positive_root, [_registry_row()])
+    _write_de_table(
+        zero_positive_root,
+        "gene_id\tlogFC\tFDR\n"
+        "ENSG00000000001\t0.2\t0.50\n"
+        "ENSG00000000002\t0.3\t0.60\n",
+    )
+    monkeypatch.chdir(zero_positive_root)
+
+    zero_positive = validate_experiments(zero_positive_tsv)
+    assert not zero_positive.ok
+    assert "no positive genes" in zero_positive.issues[0].message
+
+    zero_negative_root = tmp_path / "zero_negative"
+    zero_negative_tsv = _write_registry(zero_negative_root, [_registry_row()])
+    _write_de_table(
+        zero_negative_root,
+        "gene_id\tlogFC\tFDR\n"
+        "ENSG00000000001\t-2.0\t0.01\n"
+        "ENSG00000000002\t-3.0\t0.02\n",
+    )
+    monkeypatch.chdir(zero_negative_root)
+
+    zero_negative = validate_experiments(zero_negative_tsv)
+    assert not zero_negative.ok
+    assert "no negative genes" in zero_negative.issues[0].message
+
+
+def test_validate_experiments_cli_returns_nonzero_on_failure(tmp_path):
+    experiments_tsv = _write_registry(tmp_path, [_registry_row()])
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "funmirbench.validate_experiments",
+            "--experiments-tsv",
+            str(experiments_tsv),
+        ],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "Validation issues" in result.stdout + result.stderr


### PR DESCRIPTION
  - Validate TSV registry structure, duplicate IDs/paths, and perturbation values.
  - Validate DE tables for required columns, unique Ensembl-like gene IDs, numeric `logFC`/`FDR`, and valid FDR range.
  - Require at least one positive and one negative gene under default benchmark thresholds.
  - Exit nonzero on validation failures.
  - Add validator tests and README notes.

Test:

  uv run funmirbench-validate-experiments --experiments-tsv metadata/mirna_experiment_info.tsv
  uv run pytest tests/test_validate_experiments.py tests/test_join.py tests/test_de_table.py -q