### PR TITLE
Validate predictor output files before benchmark runs

### DIFF
--- a/funmirbench/benchmark.py
+++ b/funmirbench/benchmark.py
@@ -17,6 +17,7 @@ from funmirbench.benchmark_config import (
     load_experiments,
     load_predictions,
     selected_experiment_paths,
+    validate_predictor_output_files,
 )
 from funmirbench.benchmark_reports import (
     _init_run_layout,
@@ -195,6 +196,15 @@ def run_benchmark(config_path):
         eval_cfg.get("report_min_common_coverage", eval_cfg.get("publication_min_common_coverage", 0.10))
     )
 
+    logger.info("Loading predictors...")
+    predictions = load_predictions(
+        root / config["predictions_tsv"],
+        config.get("predictors"),
+    )
+    if not predictions:
+        raise ValueError("Predictor selection resolved to no predictors.")
+    validate_predictor_output_files(predictions, root)
+
     logger.info("Syncing selected experiment DE tables from Zenodo...")
     synced = sync_zenodo_experiments(
         selected_experiment_paths(experiments_tsv, experiment_filters),
@@ -229,13 +239,6 @@ def run_benchmark(config_path):
     if not experiments:
         raise ValueError("Experiment selection resolved to no datasets.")
 
-    logger.info("Loading predictors...")
-    predictions = load_predictions(
-        root / config["predictions_tsv"],
-        config.get("predictors"),
-    )
-    if not predictions:
-        raise ValueError("Predictor selection resolved to no predictors.")
     evaluate_module.FIGURE_DPI = int(eval_cfg.get("figure_dpi", eval_cfg.get("publication_figure_dpi", 450)))
     out_root = (root / config.get("out_dir", "results")).resolve()
     out_root.mkdir(parents=True, exist_ok=True)

--- a/funmirbench/benchmark_config.py
+++ b/funmirbench/benchmark_config.py
@@ -73,3 +73,38 @@ def load_predictions(tsv_path, filters):
     if df["tool_id"].duplicated().any():
         raise ValueError("Duplicate tool_id values found after predictor filtering.")
     return {row["tool_id"]: row.to_dict() for _, row in df.iterrows()}
+
+
+def resolve_predictor_output_path(predictor_output_path, root):
+    path = pathlib.Path(str(predictor_output_path))
+    if not path.is_absolute():
+        path = pathlib.Path(root) / path
+    return path
+
+
+def validate_predictor_output_files(predictions, root):
+    missing = []
+    for tool_id, meta in predictions.items():
+        configured_path = meta.get("predictor_output_path")
+        if configured_path is None or pd.isna(configured_path) or str(configured_path).strip() == "":
+            missing.append((tool_id, configured_path))
+            continue
+        resolved_path = resolve_predictor_output_path(configured_path, root)
+        if not resolved_path.is_file():
+            missing.append((tool_id, configured_path))
+
+    if not missing:
+        return
+
+    lines = ["Missing predictor output files:", ""]
+    lines.extend(f"{tool_id}: {configured_path}" for tool_id, configured_path in missing)
+    lines.extend(
+        [
+            "",
+            (
+                "Generate or download the selected standardized predictor files, "
+                "or remove unavailable predictors from benchmark.yaml."
+            ),
+        ]
+    )
+    raise FileNotFoundError("\n".join(lines))

--- a/funmirbench/benchmark_config.py
+++ b/funmirbench/benchmark_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import os
 import pathlib
 import urllib.parse
 
@@ -76,7 +77,7 @@ def load_predictions(tsv_path, filters):
 
 
 def resolve_predictor_output_path(predictor_output_path, root):
-    path = pathlib.Path(str(predictor_output_path))
+    path = pathlib.Path(os.path.expandvars(str(predictor_output_path))).expanduser()
     if not path.is_absolute():
         path = pathlib.Path(root) / path
     return path

--- a/funmirbench/join.py
+++ b/funmirbench/join.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pandas as pd
 
 from funmirbench import DatasetMeta
+from funmirbench.benchmark_config import resolve_predictor_output_path
 from funmirbench.de_table import find_gene_id_column, read_de_table
 
 
@@ -148,9 +149,7 @@ def load_tool_scores(
     logger=None,
 ) -> tuple[pd.DataFrame, Path]:
     start = time.perf_counter()
-    path = Path(tool_meta["predictor_output_path"])
-    if not path.is_absolute():
-        path = root / path
+    path = resolve_predictor_output_path(tool_meta["predictor_output_path"], root)
     score_direction = str(tool_meta.get("score_direction", "higher_is_stronger") or "higher_is_stronger")
 
     df, rank_map, rows_read = _read_relevant_tool_scores(


### PR DESCRIPTION
  ## Summary

  - Adds preflight validation for selected predictor output files before experiment sync, validation, joining, or evaluation starts.
  - Resolves relative `predictor_output_path` values from the benchmark config root, matching join-time path behavior.
  - Reports all missing selected predictor files in one clear `FileNotFoundError`, including each `tool_id` and configured `predictor_output_path`.
  - Reuses the shared predictor path resolver in the join code to keep validation and loading behavior aligned.

  ## Validation

  - `uv run python -m py_compile funmirbench/benchmark.py funmirbench/benchmark_config.py funmirbench/join.py`