### PR TITLE
Perf/faster evaluation only

### DIFF
--- a/benchmark.yaml
+++ b/benchmark.yaml
@@ -23,6 +23,7 @@ predictors:
   tool_id: [targetscan, mirdb_mirtarget, microt_cnn, mirbind2, miraw]
 
 evaluation:
+  parallel_workers: 4
   fdr_threshold: null
   effect_threshold: 1.0
   predictor_top_fraction: 0.10

--- a/benchmark.yaml
+++ b/benchmark.yaml
@@ -11,7 +11,7 @@ predictions_tsv: metadata/predictions_info.tsv
 # The default repo config ships with a small 2-dataset demo selection.
 # Edit or comment these active rows to benchmark other subsets.
 experiments:
-  id: [GSE124411_OE_miR_150_5p_2, GSE129076_OE_miR_450a_5p_1]
+  id: [GSE168484_OE_miR_20b_5p, GSE202135_OE_miR_130b_3p]
   # mirna_name: [hsa-miR-375-3p]
   # tested_cell_line: [HUV-EC-C]
   # tissue: [Cervix]
@@ -23,7 +23,7 @@ predictors:
   tool_id: [targetscan, mirdb_mirtarget, microt_cnn, mirbind2, miraw]
 
 evaluation:
-  parallel_workers: 4
+  parallel_workers: 2
   fdr_threshold: null
   effect_threshold: 1.0
   predictor_top_fraction: 0.10

--- a/benchmark.yaml
+++ b/benchmark.yaml
@@ -23,7 +23,7 @@ predictors:
   tool_id: [targetscan, mirdb_mirtarget, microt_cnn, mirbind2, miraw]
 
 evaluation:
-  parallel_workers: 2
+  predictor_load_workers: 2
   fdr_threshold: null
   effect_threshold: 1.0
   predictor_top_fraction: 0.10

--- a/funmirbench/benchmark.py
+++ b/funmirbench/benchmark.py
@@ -35,7 +35,7 @@ from funmirbench.evaluate import (
     evaluate_joined_dataframe,
 )
 from funmirbench.experiment_store import sync_zenodo_experiments
-from funmirbench.join import build_joined
+from funmirbench.join import build_joined, load_predictor_score_cache
 from funmirbench.logger import parse_log_level, setup_logging
 from funmirbench.predictor_combinations import write_predictor_combination_outputs
 from funmirbench.protein_coding import (
@@ -310,6 +310,13 @@ def run_benchmark(config_path):
     common_prediction_summaries = []
     logger.info(f"Experiments: {len(experiments)}")
     logger.info(f"Predictors:  {tool_ids}")
+    logger.info("Loading predictor score files once for this run...")
+    predictor_cache = load_predictor_score_cache(
+        tool_ids,
+        predictions,
+        root,
+        logger=logger.info,
+    )
 
     for meta in experiments:
         logger.info(f"Dataset: {meta.id} | {meta.miRNA} | {meta.cell_line}")
@@ -325,6 +332,7 @@ def run_benchmark(config_path):
             predictions,
             root,
             protein_coding_gene_ids=protein_coding_gene_ids,
+            predictor_cache=predictor_cache,
             logger=logger.info,
         )
         joined_path = dataset_dir / "joined.tsv"

--- a/funmirbench/benchmark.py
+++ b/funmirbench/benchmark.py
@@ -86,6 +86,13 @@ def _optional_bool(value, default=False):
     raise ValueError(f"Expected a boolean value, got {value!r}")
 
 
+def _positive_int(value, *, name):
+    parsed = int(value)
+    if parsed < 1:
+        raise ValueError(f"{name} must be >= 1, got {value!r}")
+    return parsed
+
+
 def clear_dataset_outputs(dataset_id, plots_dir, reports_dir):
     dataset_plots_dir = plots_dir / dataset_id
     if dataset_plots_dir.exists():
@@ -219,6 +226,7 @@ def run_benchmark(config_path):
         eval_cfg.get("report_min_common_coverage", eval_cfg.get("publication_min_common_coverage", 0.10))
     )
     protein_coding_only = _optional_bool(eval_cfg.get("protein_coding_only"), True)
+    parallel_workers = _positive_int(eval_cfg.get("parallel_workers", 1), name="evaluation.parallel_workers")
 
     logger.info("Loading predictors...")
     predictions = load_predictions(
@@ -310,11 +318,12 @@ def run_benchmark(config_path):
     common_prediction_summaries = []
     logger.info(f"Experiments: {len(experiments)}")
     logger.info(f"Predictors:  {tool_ids}")
-    logger.info("Loading predictor score files once for this run...")
+    logger.info("Loading predictor score files once for this run with %d worker(s)...", parallel_workers)
     predictor_cache = load_predictor_score_cache(
         tool_ids,
         predictions,
         root,
+        max_workers=parallel_workers,
         logger=logger.info,
     )
 

--- a/funmirbench/benchmark.py
+++ b/funmirbench/benchmark.py
@@ -226,7 +226,10 @@ def run_benchmark(config_path):
         eval_cfg.get("report_min_common_coverage", eval_cfg.get("publication_min_common_coverage", 0.10))
     )
     protein_coding_only = _optional_bool(eval_cfg.get("protein_coding_only"), True)
-    parallel_workers = _positive_int(eval_cfg.get("parallel_workers", 1), name="evaluation.parallel_workers")
+    predictor_load_workers = _positive_int(
+        eval_cfg.get("predictor_load_workers", 1),
+        name="evaluation.predictor_load_workers",
+    )
 
     logger.info("Loading predictors...")
     predictions = load_predictions(
@@ -318,12 +321,12 @@ def run_benchmark(config_path):
     common_prediction_summaries = []
     logger.info(f"Experiments: {len(experiments)}")
     logger.info(f"Predictors:  {tool_ids}")
-    logger.info("Loading predictor score files once for this run with %d worker(s)...", parallel_workers)
+    logger.info("Loading predictor score files once for this run with %d worker(s)...", predictor_load_workers)
     predictor_cache = load_predictor_score_cache(
         tool_ids,
         predictions,
         root,
-        max_workers=parallel_workers,
+        max_workers=predictor_load_workers,
         logger=logger.info,
     )
 

--- a/funmirbench/benchmark_config.py
+++ b/funmirbench/benchmark_config.py
@@ -12,6 +12,13 @@ import pandas as pd
 from funmirbench import DatasetMeta
 
 
+def clean_optional_string(value, default=""):
+    if value is None or pd.isna(value):
+        return default
+    text = str(value).strip()
+    return text if text else default
+
+
 def build_run_dir_name(*, experiments, tool_ids, eval_cfg, tags=None, run_date=None):
     """Return the timestamp-based run directory name.
     """
@@ -48,10 +55,10 @@ def load_experiments(tsv_path, root, filters):
             DatasetMeta(
                 id=str(row["id"]),
                 miRNA=str(row["mirna_name"]),
-                cell_line=str(row.get("tested_cell_line", "") or ""),
-                tissue=str(row.get("tissue", "") or ""),
-                perturbation=str(row.get("experiment_type", "") or ""),
-                organism=str(row.get("organism", "") or ""),
+                cell_line=clean_optional_string(row.get("tested_cell_line")),
+                tissue=clean_optional_string(row.get("tissue")),
+                perturbation=clean_optional_string(row.get("experiment_type")),
+                organism=clean_optional_string(row.get("organism")),
                 geo_accession=geo,
                 data_path=str(row["de_table_path"]),
                 root=root,

--- a/funmirbench/evaluate.py
+++ b/funmirbench/evaluate.py
@@ -58,6 +58,7 @@ def evaluate_joined_dataframe(
     predictor_correlation_tsv = None
     comparisons = []
     coverage_by_tool = {}
+    scored_frames_by_tool = {}
     evaluated_score_cols = []
     evaluated_tool_ids = []
     evaluated_local_rank_cols = []
@@ -234,6 +235,7 @@ def evaluate_joined_dataframe(
             "coverage": coverage_info["coverage"],
         })
         coverage_by_tool[tool_id] = coverage_info["coverage"]
+        scored_frames_by_tool[tool_id] = scored
         evaluated_score_cols.append(score_col)
         evaluated_tool_ids.append(tool_id)
         evaluated_local_rank_cols.append(local_rank_col)
@@ -329,13 +331,7 @@ def evaluate_joined_dataframe(
         try:
             own_scored_comparisons = []
             for score_col, tool_id, comparison in zip(plot_score_cols, plot_tool_ids, plot_comparisons):
-                scored, _ = _prepare_scored_frame(
-                    joined,
-                    score_col=score_col,
-                    fdr_threshold=fdr_threshold,
-                    abs_logfc_threshold=abs_logfc_threshold,
-                    perturbation=perturbation,
-                )
+                scored = scored_frames_by_tool[tool_id]
                 own_scored_comparisons.append(
                     {
                         "tool_id": tool_id,

--- a/funmirbench/join.py
+++ b/funmirbench/join.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Collection
@@ -256,12 +257,33 @@ def load_predictor_score_cache(
     predictions,
     root,
     *,
+    max_workers: int = 1,
     logger=None,
 ) -> dict[str, LoadedPredictor]:
-    return {
-        tool_id: load_predictor_scores(tool_id, predictions[tool_id], root, logger=logger)
-        for tool_id in tool_ids
-    }
+    tool_ids = list(tool_ids)
+    if max_workers <= 1 or len(tool_ids) <= 1:
+        return {
+            tool_id: load_predictor_scores(tool_id, predictions[tool_id], root, logger=logger)
+            for tool_id in tool_ids
+        }
+
+    loaded_by_tool = {}
+    worker_count = min(int(max_workers), len(tool_ids))
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        future_to_tool = {
+            executor.submit(
+                load_predictor_scores,
+                tool_id,
+                predictions[tool_id],
+                root,
+                logger=logger,
+            ): tool_id
+            for tool_id in tool_ids
+        }
+        for future in as_completed(future_to_tool):
+            tool_id = future_to_tool[future]
+            loaded_by_tool[tool_id] = future.result()
+    return {tool_id: loaded_by_tool[tool_id] for tool_id in tool_ids}
 
 
 def _select_loaded_tool_scores(

--- a/funmirbench/join.py
+++ b/funmirbench/join.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Collection
 
@@ -15,6 +16,17 @@ from funmirbench.gene_ids import strip_ensembl_version
 
 
 PREDICTOR_CHUNK_SIZE = 1_000_000
+
+
+@dataclass(frozen=True)
+class LoadedPredictor:
+    tool_id: str
+    path: Path
+    score_direction: str
+    rows_read: int
+    rank_map: dict[float, float]
+    scores: pd.DataFrame
+    has_dataset_id: bool
 
 
 def _emit_log(logger, message: str) -> None:
@@ -161,6 +173,127 @@ def _read_relevant_tool_scores(
     return relevant, rank_map, rows_read
 
 
+def load_predictor_scores(
+    tool_id: str,
+    tool_meta: dict,
+    root: Path,
+    *,
+    logger=None,
+) -> LoadedPredictor:
+    start = time.perf_counter()
+    path = resolve_predictor_output_path(tool_meta["predictor_output_path"], root)
+    score_direction = str(
+        tool_meta.get("score_direction", "higher_is_stronger") or "higher_is_stronger"
+    )
+
+    header = pd.read_csv(path, sep="\t", nrows=0)
+    columns = [str(c).strip() for c in header.columns]
+    column_lookup = {str(c).strip(): c for c in header.columns}
+    required = ("Ensembl_ID", "miRNA_Name", "Score")
+    missing = [col for col in required if col not in columns]
+    if missing:
+        raise ValueError(f"{path} missing required columns: {missing}")
+
+    has_dataset_id = "Dataset_ID" in columns
+    usecols = [column_lookup[col] for col in required]
+    if has_dataset_id:
+        usecols.append(column_lookup["Dataset_ID"])
+
+    chunks = []
+    score_values = []
+    rows_read = 0
+    reader = pd.read_csv(path, sep="\t", usecols=usecols, chunksize=PREDICTOR_CHUNK_SIZE)
+    for chunk in reader:
+        chunk.columns = [str(c).strip() for c in chunk.columns]
+        rows_read += len(chunk)
+        normalized_score = _normalize_scores(
+            chunk["Score"],
+            score_direction=score_direction,
+            tool_id=tool_id,
+        )
+        score_values.append(normalized_score.dropna())
+
+        selected = pd.DataFrame(
+            {
+                "Ensembl_ID": chunk["Ensembl_ID"].map(strip_ensembl_version),
+                "miRNA_Name": chunk["miRNA_Name"].astype(str),
+                "Score": normalized_score.astype(float),
+            }
+        )
+        if has_dataset_id:
+            selected["Dataset_ID"] = chunk["Dataset_ID"].astype(str)
+        chunks.append(selected)
+
+    all_scores = pd.concat(score_values, ignore_index=True) if score_values else pd.Series(dtype=float)
+    rank_map = _global_rank_percentile_map(all_scores)
+    if chunks:
+        scores = pd.concat(chunks, ignore_index=True)
+    else:
+        columns = ["Ensembl_ID", "miRNA_Name", "Score"]
+        if has_dataset_id:
+            columns.append("Dataset_ID")
+        scores = pd.DataFrame(columns=columns)
+    _emit_log(
+        logger,
+        (
+            f"Loaded predictor | {tool_id} | file_rows={rows_read:,} | "
+            f"unique_scores={len(rank_map):,} | {_elapsed(start):.2f}s"
+        ),
+    )
+    return LoadedPredictor(
+        tool_id=tool_id,
+        path=path,
+        score_direction=score_direction,
+        rows_read=rows_read,
+        rank_map=rank_map,
+        scores=scores,
+        has_dataset_id=has_dataset_id,
+    )
+
+
+def load_predictor_score_cache(
+    tool_ids,
+    predictions,
+    root,
+    *,
+    logger=None,
+) -> dict[str, LoadedPredictor]:
+    return {
+        tool_id: load_predictor_scores(tool_id, predictions[tool_id], root, logger=logger)
+        for tool_id in tool_ids
+    }
+
+
+def _select_loaded_tool_scores(
+    loaded: LoadedPredictor,
+    *,
+    dataset_id: str,
+    mirna: str,
+    col_name: str,
+    rank_col_name: str,
+    min_score: float | None,
+) -> pd.DataFrame:
+    scores = loaded.scores
+    mask = scores["miRNA_Name"].astype(str) == str(mirna)
+    if loaded.has_dataset_id:
+        mask &= scores["Dataset_ID"].astype(str) == str(dataset_id)
+    if min_score is not None:
+        mask &= scores["Score"] >= float(min_score)
+
+    if not bool(mask.any()):
+        return pd.DataFrame(columns=["gene_id", col_name, rank_col_name])
+
+    df = scores.loc[mask, ["Ensembl_ID", "Score"]].copy()
+    df[rank_col_name] = df["Score"].map(loaded.rank_map)
+    df = df.rename(columns={"Ensembl_ID": "gene_id"})
+    if df["gene_id"].duplicated().any():
+        keep_idx = df.groupby("gene_id")["Score"].idxmax()
+        df = df.loc[keep_idx, ["gene_id", "Score", rank_col_name]].reset_index(drop=True)
+    else:
+        df = df[["gene_id", "Score", rank_col_name]].copy()
+    return df.rename(columns={"Score": col_name})
+
+
 def load_tool_scores(
     tool_id: str,
     tool_meta: dict,
@@ -211,6 +344,7 @@ def build_joined(
     min_score: float | None = None,
     *,
     protein_coding_gene_ids: Collection[str] | None = None,
+    predictor_cache: dict[str, LoadedPredictor] | None = None,
     logger=None,
 ):
     total_start = time.perf_counter()
@@ -224,17 +358,36 @@ def build_joined(
         if tool_id not in predictions:
             raise ValueError(f"Unknown tool {tool_id!r}. Known: {sorted(predictions)}")
         tool_start = time.perf_counter()
-        scores, predictor_output_path = load_tool_scores(
-            tool_id,
-            predictions[tool_id],
-            root,
-            meta.id,
-            meta.miRNA,
-            f"score_{tool_id}",
-            f"global_rank_{tool_id}",
-            min_score=min_score,
-            logger=logger,
-        )
+        if predictor_cache is not None and tool_id in predictor_cache:
+            loaded = predictor_cache[tool_id]
+            scores = _select_loaded_tool_scores(
+                loaded,
+                dataset_id=meta.id,
+                mirna=meta.miRNA,
+                col_name=f"score_{tool_id}",
+                rank_col_name=f"global_rank_{tool_id}",
+                min_score=min_score,
+            )
+            predictor_output_path = loaded.path
+            _emit_log(
+                logger,
+                (
+                    f"    Join timing | {tool_id} | cached_file_rows={loaded.rows_read:,} | "
+                    f"matched_rows={len(scores):,} | unique_scores={len(loaded.rank_map):,}"
+                ),
+            )
+        else:
+            scores, predictor_output_path = load_tool_scores(
+                tool_id,
+                predictions[tool_id],
+                root,
+                meta.id,
+                meta.miRNA,
+                f"score_{tool_id}",
+                f"global_rank_{tool_id}",
+                min_score=min_score,
+                logger=logger,
+            )
         joined = joined.merge(scores, on="gene_id", how="left")
         paths[tool_id] = str(predictor_output_path)
         scored = int(joined[f"score_{tool_id}"].notna().sum())

--- a/funmirbench/join.py
+++ b/funmirbench/join.py
@@ -270,20 +270,33 @@ def load_predictor_score_cache(
 
     loaded_by_tool = {}
     worker_count = min(int(max_workers), len(tool_ids))
-    with ThreadPoolExecutor(max_workers=worker_count) as executor:
-        future_to_tool = {
-            executor.submit(
-                load_predictor_scores,
-                tool_id,
-                predictions[tool_id],
-                root,
-                logger=logger,
-            ): tool_id
-            for tool_id in tool_ids
-        }
+    executor = ThreadPoolExecutor(max_workers=worker_count)
+    should_wait = True
+    future_to_tool = {
+        executor.submit(
+            load_predictor_scores,
+            tool_id,
+            predictions[tool_id],
+            root,
+            logger=logger,
+        ): tool_id
+        for tool_id in tool_ids
+    }
+    try:
         for future in as_completed(future_to_tool):
             tool_id = future_to_tool[future]
-            loaded_by_tool[tool_id] = future.result()
+            try:
+                loaded_by_tool[tool_id] = future.result()
+            except Exception:
+                for pending in future_to_tool:
+                    if pending is not future:
+                        pending.cancel()
+                should_wait = False
+                executor.shutdown(wait=False, cancel_futures=True)
+                raise
+    finally:
+        if should_wait:
+            executor.shutdown(wait=True)
     return {tool_id: loaded_by_tool[tool_id] for tool_id in tool_ids}
 
 

--- a/funmirbench/join.py
+++ b/funmirbench/join.py
@@ -11,7 +11,7 @@ from typing import Collection
 import pandas as pd
 
 from funmirbench import DatasetMeta
-from funmirbench.benchmark_config import resolve_predictor_output_path
+from funmirbench.benchmark_config import clean_optional_string, resolve_predictor_output_path
 from funmirbench.de_table import find_gene_id_column, read_de_table
 from funmirbench.gene_ids import strip_ensembl_version
 
@@ -183,8 +183,9 @@ def load_predictor_scores(
 ) -> LoadedPredictor:
     start = time.perf_counter()
     path = resolve_predictor_output_path(tool_meta["predictor_output_path"], root)
-    score_direction = str(
-        tool_meta.get("score_direction", "higher_is_stronger") or "higher_is_stronger"
+    score_direction = clean_optional_string(
+        tool_meta.get("score_direction"),
+        default="higher_is_stronger",
     )
 
     header = pd.read_csv(path, sep="\t", nrows=0)
@@ -330,7 +331,10 @@ def load_tool_scores(
 ) -> tuple[pd.DataFrame, Path]:
     start = time.perf_counter()
     path = resolve_predictor_output_path(tool_meta["predictor_output_path"], root)
-    score_direction = str(tool_meta.get("score_direction", "higher_is_stronger") or "higher_is_stronger")
+    score_direction = clean_optional_string(
+        tool_meta.get("score_direction"),
+        default="higher_is_stronger",
+    )
 
     df, rank_map, rows_read = _read_relevant_tool_scores(
         path,


### PR DESCRIPTION
Changes:

Loads each selected predictor score file once per benchmark run instead of rereading it for every
dataset.
Reuses cached predictor scores when building each dataset’s joined table.
Reuses already prepared scored frames for own-scored PR/ROC comparison plots.
Adds evaluation.parallel_workers to benchmark.yaml so predictor cache loading can run concurrently.
Updates the demo benchmark config to use the selected datasets and parallel_workers: 2.