### PR TITLE
Support curated RNA-seq experiment inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ That downloader fetches:
 
 - the real `GSE253003` count matrix
 - the real `GSE93717` FASTQ files
-- the shared Homo sapiens Ensembl v109 genome FASTA and GTF used by the reads example
+- the shared Homo sapiens Ensembl v115 genome FASTA and GTF used by the reads example
 
 Run the real count-matrix example:
 
@@ -147,8 +147,14 @@ Tracked example configs:
 
 Reads configs can either:
 
-- use local `reads_1` and optional `reads_2`
+- use local `reads_1` and optional `reads_2`; each value may be one path or a
+  list of technical-run paths for the same biological sample
 - use local `genome_fasta_path` and `gtf_path`
+
+Technical runs listed for one sample are combined before QC and trimming.
+Single-end and paired-end biological samples may coexist in one comparison;
+featureCounts processes the two layouts separately and the pipeline combines
+their gene-count columns before DESeq2.
 
 So the practical reads flow is:
 
@@ -156,8 +162,8 @@ So the practical reads flow is:
 2. run `uv run funmirbench-experiments-download-examples`
 3. run `uv run funmirbench-experiments --config pipelines/experiments/configs/gse93717.reads.example.yaml`
 
-The shipped reads example now points at the downloaded Ensembl v109 reference source files under
-`data/experiments/raw/refs/ensembl_v109/`, so it builds the derived STAR index automatically.
+The shipped reads example now points at the downloaded Ensembl v115 reference source files under
+`data/experiments/raw/refs/ensembl_v115/`, so it builds the derived STAR index automatically.
 
 Each run writes:
 
@@ -350,4 +356,10 @@ uv run funmirbench-validate-experiments --experiments-tsv metadata/mirna_experim
 uv run funmirbench-experiments-download-examples
 uv run funmirbench-experiments --config config.yaml
 uv run funmirbench-sync-metadata
+```
+
+## Tests
+
+```bash
+uv run python -m unittest discover -s tests
 ```

--- a/funmirbench/experiments_pipeline.py
+++ b/funmirbench/experiments_pipeline.py
@@ -409,26 +409,76 @@ def run_de_from_counts(
     return {"run_dir": str(run_dir), "de_table_path": str(out_path)}
 
 
+def normalize_read_paths(
+    value: str | list[str] | None,
+    *,
+    field_name: str,
+    sample_id: str,
+    root: pathlib.Path,
+    repo: pathlib.Path,
+) -> list[str]:
+    if value is None:
+        values = []
+    elif isinstance(value, list):
+        values = value
+    elif isinstance(value, str):
+        values = [value]
+    else:
+        raise ValueError(
+            f"Sample {sample_id!r} has invalid {field_name}; "
+            "expected a path or list of paths."
+        )
+    paths = [
+        normalize_space(item)
+        for item in values
+        if item is not None and normalize_space(item)
+    ]
+    if not paths:
+        raise ValueError(f"Sample {sample_id!r} must provide {field_name}.")
+
+    resolved_paths = []
+    for path_value in paths:
+        resolved_path = resolve_path(path_value, root=root, repo=repo)
+        if not resolved_path.exists():
+            raise ValueError(
+                f"{field_name} for sample {sample_id!r} does not exist: {resolved_path}"
+            )
+        resolved_paths.append(str(resolved_path))
+    return resolved_paths
+
+
 def normalize_sample_entry(sample: dict, *, group_name: str, root: pathlib.Path, repo: pathlib.Path) -> dict:
     sample_id = normalize_space(sample.get("sample_id") or sample.get("id") or sample.get("accession", ""))
     if not sample_id:
         raise ValueError(f"Each {group_name} sample must define sample_id.")
 
-    reads_1_value = normalize_space(sample.get("reads_1", ""))
-    reads_2_value = normalize_space(sample.get("reads_2", ""))
-    if not reads_1_value:
-        raise ValueError(f"Sample {sample_id!r} must provide reads_1.")
-    resolved_reads_1 = resolve_path(reads_1_value, root=root, repo=repo)
-    if not resolved_reads_1.exists():
-        raise ValueError(f"reads_1 for sample {sample_id!r} does not exist: {resolved_reads_1}")
-    reads_1 = str(resolved_reads_1)
-    reads_2 = ""
-
-    if reads_2_value:
-        resolved_reads_2 = resolve_path(reads_2_value, root=root, repo=repo)
-        if not resolved_reads_2.exists():
-            raise ValueError(f"reads_2 for sample {sample_id!r} does not exist: {resolved_reads_2}")
-        reads_2 = str(resolved_reads_2)
+    reads_1 = normalize_read_paths(
+        sample.get("reads_1", ""),
+        field_name="reads_1",
+        sample_id=sample_id,
+        root=root,
+        repo=repo,
+    )
+    reads_2_value = sample.get("reads_2", "")
+    reads_2_values = reads_2_value if isinstance(reads_2_value, list) else [reads_2_value]
+    has_reads_2 = any(
+        item is not None and normalize_space(item) for item in reads_2_values
+    )
+    reads_2 = (
+        normalize_read_paths(
+            reads_2_value,
+            field_name="reads_2",
+            sample_id=sample_id,
+            root=root,
+            repo=repo,
+        )
+        if has_reads_2
+        else []
+    )
+    if reads_2 and len(reads_1) != len(reads_2):
+        raise ValueError(
+            f"Sample {sample_id!r} must provide the same number of reads_1 and reads_2 files."
+        )
 
     count_matrix_column = normalize_space(sample.get("count_matrix_column", "")) or sample_id
     return {
@@ -441,6 +491,60 @@ def normalize_sample_entry(sample: dict, *, group_name: str, root: pathlib.Path,
         "title": sample_id,
         "group_label": group_name,
     }
+
+
+def open_reads_file(path: str):
+    reads_path = pathlib.Path(path)
+    if reads_path.suffix == ".gz":
+        return gzip.open(reads_path, "rb")
+    return reads_path.open("rb")
+
+
+def combine_reads_files(paths: list[str], output_path: pathlib.Path) -> pathlib.Path:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with (
+        output_path.open("wb") as output_handle,
+        gzip.GzipFile(fileobj=output_handle, mode="wb", mtime=0) as compressed_handle,
+    ):
+        for path in paths:
+            with open_reads_file(path) as input_handle:
+                shutil.copyfileobj(input_handle, compressed_handle)
+    return output_path
+
+
+def materialize_sample_reads(sample: dict, *, run_dir: pathlib.Path) -> dict:
+    reads_1_files = list(sample["reads_1"])
+    reads_2_files = list(sample["reads_2"])
+    materialized = dict(sample)
+    materialized["source_reads_1"] = reads_1_files
+    materialized["source_reads_2"] = reads_2_files
+
+    if len(reads_1_files) == 1:
+        materialized["reads_1"] = reads_1_files[0]
+        materialized["reads_2"] = reads_2_files[0] if reads_2_files else ""
+        return materialized
+
+    output_dir = run_dir / "combined_reads" / sample["sample_id"]
+    paired = bool(reads_2_files)
+    reads_1_name = (
+        f"{sample['sample_id']}_R1.fastq.gz"
+        if paired
+        else f"{sample['sample_id']}.fastq.gz"
+    )
+    materialized["reads_1"] = str(
+        combine_reads_files(reads_1_files, output_dir / reads_1_name)
+    )
+    materialized["reads_2"] = (
+        str(
+            combine_reads_files(
+                reads_2_files,
+                output_dir / f"{sample['sample_id']}_R2.fastq.gz",
+            )
+        )
+        if paired
+        else ""
+    )
+    return materialized
 
 
 def load_reads_samples(config: dict, *, config_path: pathlib.Path, repo: pathlib.Path) -> tuple[list[dict], list[dict]]:
@@ -627,7 +731,22 @@ def infer_library_layout(samples: list[dict]) -> str:
         return "paired"
     if not any(paired_flags):
         return "single"
-    raise ValueError("Mixed single-end and paired-end samples are not supported in one reads config.")
+    return "mixed"
+
+
+def group_sample_ids_by_layout(
+    samples: list[dict], sample_order: list[str]
+) -> dict[str, list[str]]:
+    samples_by_id = {sample["sample_id"]: sample for sample in samples}
+    groups = {
+        layout: [
+            sample_id
+            for sample_id in sample_order
+            if bool(samples_by_id[sample_id]["reads_2"]) == (layout == "paired")
+        ]
+        for layout in ("single", "paired")
+    }
+    return {layout: sample_ids for layout, sample_ids in groups.items() if sample_ids}
 
 
 def run_fastqc(
@@ -793,13 +912,15 @@ def run_featurecounts(
     bam_paths: dict[str, pathlib.Path],
     sample_order: list[str],
     paired_end: bool,
+    output_label: str = "",
 ) -> tuple[pathlib.Path, list[str], pathlib.Path, pathlib.Path]:
     require_local_binary("featureCounts")
     threads = int(source_cfg.get("featurecounts_threads", default_thread_count(cap=16)))
     logger.info("Running featureCounts with %s threads...", threads)
     feature_type = normalize_space(source_cfg.get("featurecounts_feature_type", "")) or "exon"
     gene_attribute = normalize_space(source_cfg.get("featurecounts_gene_attribute", "")) or "gene_id"
-    output_path = run_dir / "featurecounts_counts.tsv"
+    suffix = f"_{output_label}" if output_label else ""
+    output_path = run_dir / f"featurecounts{suffix}_counts.tsv"
     command = [
         "featureCounts",
         "-T",
@@ -817,8 +938,8 @@ def run_featurecounts(
         command.extend(["-p", "--countReadPairs"])
     command.extend(str(arg) for arg in source_cfg.get("featurecounts_extra_args", []))
     command.extend(str(bam_paths[sample_id]) for sample_id in sample_order)
-    stdout_path = run_dir / "featurecounts.stdout.txt"
-    stderr_path = run_dir / "featurecounts.stderr.txt"
+    stdout_path = run_dir / f"featurecounts{suffix}.stdout.txt"
+    stderr_path = run_dir / f"featurecounts{suffix}.stderr.txt"
     run_logged_command(
         command,
         cwd=repo,
@@ -864,6 +985,31 @@ def build_featurecounts_matrix(
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     matrix.to_csv(out_path, sep="\t", index=False)
+    return out_path
+
+
+def combine_count_matrices(
+    matrix_paths: list[pathlib.Path],
+    sample_order: list[str],
+    out_path: pathlib.Path,
+) -> pathlib.Path:
+    matrices = [pd.read_csv(path, sep="\t") for path in matrix_paths]
+    if not matrices:
+        raise ValueError("No count matrices were provided.")
+
+    combined = matrices[0]
+    for matrix in matrices[1:]:
+        combined = combined.merge(matrix, on="gene_id", how="outer", validate="one_to_one")
+
+    required_columns = ["gene_id", *sample_order]
+    missing = [column for column in required_columns if column not in combined.columns]
+    if missing:
+        raise ValueError(f"Combined count matrix is missing sample columns: {missing}")
+    if combined[required_columns].isna().any().any():
+        raise ValueError("featureCounts runs produced different gene sets.")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    combined[required_columns].to_csv(out_path, sep="\t", index=False)
     return out_path
 
 
@@ -925,9 +1071,15 @@ def run_reads_mode(
     source_cfg = config.get("source", {})
     logger.info("Loading reads config...")
     control_samples, treated_samples = load_reads_samples(config, config_path=config_path, repo=repo)
+    control_samples = [
+        materialize_sample_reads(sample, run_dir=run_dir) for sample in control_samples
+    ]
+    treated_samples = [
+        materialize_sample_reads(sample, run_dir=run_dir) for sample in treated_samples
+    ]
     sample_sheet = write_reads_sample_sheet(run_dir, control_samples, treated_samples)
     sample_order = [sample["sample_id"] for sample in control_samples + treated_samples]
-    paired_end = infer_library_layout(control_samples + treated_samples) == "paired"
+    library_layout = infer_library_layout(control_samples + treated_samples)
 
     logger.info("Preparing references...")
     reference_assets = prepare_reads_reference_assets(
@@ -1017,24 +1169,56 @@ def run_reads_mode(
         star_stdout[sample["sample_id"]] = str(stdout_path)
         star_stderr[sample["sample_id"]] = str(stderr_path)
 
-    featurecounts_output, featurecounts_command, featurecounts_stdout, featurecounts_stderr = run_featurecounts(
-        source_cfg=source_cfg,
-        repo=repo,
-        run_dir=run_dir,
-        gtf_path=gtf_path,
-        bam_paths=bam_paths,
-        sample_order=sample_order,
-        paired_end=paired_end,
+    layout_groups = group_sample_ids_by_layout(
+        control_samples + treated_samples, sample_order
     )
 
+    featurecounts_runs = {}
+    count_matrix_parts = []
+    for layout, layout_sample_order in layout_groups.items():
+        output_label = layout if library_layout == "mixed" else ""
+        output, command, stdout_path, stderr_path = run_featurecounts(
+            source_cfg=source_cfg,
+            repo=repo,
+            run_dir=run_dir,
+            gtf_path=gtf_path,
+            bam_paths=bam_paths,
+            sample_order=layout_sample_order,
+            paired_end=layout == "paired",
+            output_label=output_label,
+        )
+        matrix_path = run_dir / (
+            f"counts_matrix_{layout}.tsv" if library_layout == "mixed" else "counts_matrix.tsv"
+        )
+        build_featurecounts_matrix(
+            featurecounts_path=output,
+            bam_paths=bam_paths,
+            sample_order=layout_sample_order,
+            out_path=matrix_path,
+        )
+        count_matrix_parts.append(matrix_path)
+        featurecounts_runs[layout] = {
+            "command": command,
+            "stdout": str(stdout_path),
+            "stderr": str(stderr_path),
+            "output": str(output),
+        }
 
+    counts_matrix_path = run_dir / "counts_matrix.tsv"
+    if library_layout == "mixed":
+        combine_count_matrices(count_matrix_parts, sample_order, counts_matrix_path)
 
-    counts_matrix_path = build_featurecounts_matrix(
-        featurecounts_path=featurecounts_output,
-        bam_paths=bam_paths,
-        sample_order=sample_order,
-        out_path=run_dir / "counts_matrix.tsv",
-    )
+    featurecounts_manifest = {"featurecounts_runs": featurecounts_runs}
+    if len(featurecounts_runs) == 1:
+        only_run = next(iter(featurecounts_runs.values()))
+        featurecounts_manifest.update(
+            {
+                "featurecounts_command": only_run["command"],
+                "featurecounts_stdout": only_run["stdout"],
+                "featurecounts_stderr": only_run["stderr"],
+                "featurecounts_output": only_run["output"],
+            }
+        )
     counts_df = read_table_auto(counts_matrix_path)
     control_cols = [sample["sample_id"] for sample in control_samples]
     treated_cols = [sample["sample_id"] for sample in treated_samples]
@@ -1057,7 +1241,7 @@ def run_reads_mode(
         gene_id_column_override="gene_id",
         extra_manifest={
             "reads_sample_sheet": str(sample_sheet),
-            "library_layout": "paired" if paired_end else "single",
+            "library_layout": library_layout,
             "pipeline_stages": ["fastqc_raw", "fastp", "fastqc_trimmed", "star", "featurecounts", "deseq2"],
             "raw_fastqc_outputs": raw_fastqc_outputs,
             "raw_fastqc_commands": raw_fastqc_commands,
@@ -1083,10 +1267,7 @@ def run_reads_mode(
             "star_stdout": star_stdout,
             "star_stderr": star_stderr,
             "sample_bams": {sample_id: str(path) for sample_id, path in bam_paths.items()},
-            "featurecounts_command": featurecounts_command,
-            "featurecounts_stdout": str(featurecounts_stdout),
-            "featurecounts_stderr": str(featurecounts_stderr),
-            "featurecounts_output": str(featurecounts_output),
+            **featurecounts_manifest,
         },
     )
 

--- a/pipelines/experiments/configs/gse93717.reads.example.yaml
+++ b/pipelines/experiments/configs/gse93717.reads.example.yaml
@@ -6,10 +6,10 @@ gse: GSE93717
 source:
   mode: reads
 
-  # Default: use the shared Ensembl v109 genome reference sources downloaded by
+  # Default: use the shared Ensembl v115 genome reference sources downloaded by
   # `uv run funmirbench-experiments-download-examples`.
-  genome_fasta_path: data/experiments/raw/refs/ensembl_v109/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz
-  gtf_path: data/experiments/raw/refs/ensembl_v109/Homo_sapiens.GRCh38.109.gtf.gz
+  genome_fasta_path: data/experiments/raw/refs/ensembl_v115/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz
+  gtf_path: data/experiments/raw/refs/ensembl_v115/Homo_sapiens.GRCh38.115.gtf.gz
 
   fastqc_threads: 8
   fastp_threads: 8

--- a/pipelines/geo/README.md
+++ b/pipelines/geo/README.md
@@ -125,6 +125,8 @@ gene_id_column:      (empty)
 Provide GSM sample accessions. The pipeline resolves each GSM to its SRR run(s) via
 the NCBI API before downloading. Useful when you want to copy accessions directly from
 the GEO page, or when one sample has multiple runs that you prefer not to list individually.
+Multiple runs belonging to one GSM remain one biological sample in the generated
+config and are combined before QC and trimming.
 
 ```
 id:                  GSE129076_OE_miR_21_5p
@@ -240,14 +242,14 @@ Key options:
 The YAML is auto-generated from the TSV and uses sensible defaults, but you should
 verify and adjust the following before proceeding:
 
-- **Genome reference paths** — the defaults point to Ensembl v109 (GRCh38). If your
+- **Genome reference paths** — the defaults point to Ensembl v115 (GRCh38). If your
   experiment uses a different genome or Ensembl version, update `genome_fasta_path`
   and `gtf_path` accordingly.
 - **Thread counts** — `fastqc_threads`, `fastp_threads`, `star_threads`, and
   `featurecounts_threads` are set to fixed defaults. Adjust them to match the
   resources available on your machine.
-- **Sample identifiers** — check that `sample_id` values and file paths look correct,
-  especially for experiments with multiple SRR runs per GSM.
+- **Sample identifiers** — check that `sample_id` values and file paths look correct.
+  Multiple SRR paths for one GSM should appear under one biological sample.
 - **Metadata fields** — organism, cell line, tissue, and treatment are copied from
   the TSV; verify they are accurate before archiving results.
 

--- a/pipelines/geo/geo_download.py
+++ b/pipelines/geo/geo_download.py
@@ -57,14 +57,15 @@ REQUIRED_TSV_COLUMNS = [
 FASTQ_OUTPUT_DIR = REPO_ROOT / "data/experiments/raw"
 CONFIG_OUTPUT_DIR = REPO_ROOT / "pipelines/experiments/configs"
 
-# Default genome reference paths (Ensembl v109, downloaded by funmirbench-experiments-download-examples)
+# Default genome reference paths (Ensembl v115, downloaded by
+# funmirbench-experiments-download-examples)
 DEFAULT_GENOME_FASTA = str(
-    REPO_ROOT / "data/experiments/raw/refs/ensembl_v109"
+    REPO_ROOT / "data/experiments/raw/refs/ensembl_v115"
     / "Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz"
 )
 DEFAULT_GTF = str(
-    REPO_ROOT / "data/experiments/raw/refs/ensembl_v109"
-    / "Homo_sapiens.GRCh38.109.gtf.gz"
+    REPO_ROOT / "data/experiments/raw/refs/ensembl_v115"
+    / "Homo_sapiens.GRCh38.115.gtf.gz"
 )
 
 REQUIRED_COUNT_MATRIX_COLUMNS = [
@@ -552,12 +553,12 @@ def process_local_experiment(experiment):
 # GEO mode: build sample entries from SRR info
 # ---------------------------------------------------------------------------
 
-def build_geo_sample_entries(srr_infos, control_samples, output_dir):
+def build_geo_sample_entries(srr_infos, control_samples, condition_samples, output_dir):
     """
     Build YAML sample entry dicts from resolved SRR info.
 
-    Uses GSM accession as sample_id. If a GSM has multiple SRRs,
-    each run gets a disambiguated id: {GSM}_{SRR}.
+    Uses each GSM accession as one biological sample. Multiple SRR runs for the
+    same GSM are kept as multiple input files for that sample.
 
     Returns (control_entries, treated_entries).
     """
@@ -569,24 +570,41 @@ def build_geo_sample_entries(srr_infos, control_samples, output_dir):
     treated_entries = []
 
     for gsm, srrs in gsm_to_srrs.items():
-        for srr_info in srrs:
-            sample_id = gsm if len(srrs) == 1 else f"{gsm}_{srr_info.srr}"
-            if srr_info.layout == "PAIRED":
-                entry = {
-                    "sample_id": sample_id,
-                    "reads_1": str(output_dir / f"{srr_info.srr}_1.fastq.gz"),
-                    "reads_2": str(output_dir / f"{srr_info.srr}_2.fastq.gz"),
-                }
-            else:
-                entry = {
-                    "sample_id": sample_id,
-                    "reads_1": str(output_dir / f"{srr_info.srr}.fastq.gz"),
-                    "reads_2": "",
-                }
-            if gsm in control_samples:
-                control_entries.append(entry)
-            else:
-                treated_entries.append(entry)
+        sorted_srrs = sorted(srrs, key=lambda item: item.srr)
+        layouts = {srr_info.layout for srr_info in sorted_srrs}
+        if len(layouts) != 1:
+            raise ValueError(f"GSM {gsm} has mixed SRR library layouts: {sorted(layouts)}")
+
+        paired = next(iter(layouts)) == "PAIRED"
+        reads_1 = [
+            str(
+                output_dir
+                / (
+                    f"{srr_info.srr}_1.fastq.gz"
+                    if paired
+                    else f"{srr_info.srr}.fastq.gz"
+                )
+            )
+            for srr_info in sorted_srrs
+        ]
+        entry = {
+            "sample_id": gsm,
+            "reads_1": reads_1[0] if len(reads_1) == 1 else reads_1,
+            "reads_2": "",
+        }
+        if paired:
+            reads_2 = [
+                str(output_dir / f"{srr_info.srr}_2.fastq.gz")
+                for srr_info in sorted_srrs
+            ]
+            entry["reads_2"] = reads_2[0] if len(reads_2) == 1 else reads_2
+
+        if gsm in control_samples:
+            control_entries.append(entry)
+        elif gsm in condition_samples:
+            treated_entries.append(entry)
+        else:
+            raise ValueError(f"Resolved GSM {gsm} is not assigned to either comparison group.")
 
     return control_entries, treated_entries
 
@@ -640,7 +658,7 @@ def download_experiment(experiment, output_dir, threads):
 
     log_step(3, step_total, f"{gse}: writing manifest", prefix="EXP")
     control_entries, treated_entries = build_geo_sample_entries(
-        srr_infos, control_samples, gse_output_dir
+        srr_infos, control_samples, condition_samples, gse_output_dir
     )
     manifest = {
         "gse": gse,

--- a/tests/test_experiment_inputs.py
+++ b/tests/test_experiment_inputs.py
@@ -1,0 +1,228 @@
+import gzip
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+
+from funmirbench.experiments_pipeline import (
+    combine_count_matrices,
+    group_sample_ids_by_layout,
+    infer_library_layout,
+    materialize_sample_reads,
+    normalize_sample_entry,
+    run_reads_mode,
+)
+
+
+class ExperimentInputTests(unittest.TestCase):
+    def test_single_path_config_remains_supported(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            reads = root / "sample.fastq.gz"
+            reads.write_bytes(b"reads")
+
+            sample = normalize_sample_entry(
+                {"sample_id": "GSM1", "reads_1": str(reads)},
+                group_name="control",
+                root=root,
+                repo=root,
+            )
+            materialized = materialize_sample_reads(sample, run_dir=root / "run")
+
+            self.assertEqual(materialized["reads_1"], str(reads))
+            self.assertEqual(materialized["reads_2"], "")
+
+    def test_multiple_runs_are_materialized_as_one_biological_sample(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            run_1 = root / "run_1.fastq.gz"
+            run_2 = root / "run_2.fastq.gz"
+            with gzip.open(run_1, "wb") as handle:
+                handle.write(b"@run1\nAC\n+\nII\n")
+            with gzip.open(run_2, "wb") as handle:
+                handle.write(b"@run2\nGT\n+\nII\n")
+
+            sample = normalize_sample_entry(
+                {"sample_id": "GSM1", "reads_1": [str(run_1), str(run_2)]},
+                group_name="control",
+                root=root,
+                repo=root,
+            )
+            materialized = materialize_sample_reads(sample, run_dir=root / "run")
+
+            self.assertEqual(materialized["sample_id"], "GSM1")
+            self.assertEqual(materialized["source_reads_1"], [str(run_1), str(run_2)])
+            with gzip.open(materialized["reads_1"], "rb") as handle:
+                self.assertEqual(
+                    handle.read(),
+                    b"@run1\nAC\n+\nII\n@run2\nGT\n+\nII\n",
+                )
+
+    def test_paired_run_lists_must_have_equal_lengths(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            paths = [root / name for name in ("r1a.fastq", "r1b.fastq", "r2a.fastq")]
+            for path in paths:
+                path.write_text("reads", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "same number"):
+                normalize_sample_entry(
+                    {
+                        "sample_id": "GSM1",
+                        "reads_1": [str(paths[0]), str(paths[1])],
+                        "reads_2": [str(paths[2])],
+                    },
+                    group_name="control",
+                    root=root,
+                    repo=root,
+                )
+
+    def test_mixed_library_layout_is_supported(self):
+        samples = [
+            {"sample_id": "single", "reads_2": ""},
+            {"sample_id": "paired", "reads_2": "mate.fastq.gz"},
+        ]
+
+        self.assertEqual(infer_library_layout(samples), "mixed")
+        self.assertEqual(
+            group_sample_ids_by_layout(samples, ["paired", "single"]),
+            {"single": ["single"], "paired": ["paired"]},
+        )
+
+    def test_separate_featurecounts_matrices_are_combined_in_sample_order(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            single = root / "single.tsv"
+            paired = root / "paired.tsv"
+            output = root / "combined.tsv"
+            pd.DataFrame({"gene_id": ["ENSG1", "ENSG2"], "single": [1, 2]}).to_csv(
+                single, sep="\t", index=False
+            )
+            pd.DataFrame({"gene_id": ["ENSG1", "ENSG2"], "paired": [3, 4]}).to_csv(
+                paired, sep="\t", index=False
+            )
+
+            combine_count_matrices([single, paired], ["paired", "single"], output)
+
+            combined = pd.read_csv(output, sep="\t")
+            self.assertEqual(list(combined.columns), ["gene_id", "paired", "single"])
+            self.assertEqual(combined.to_dict(orient="list"), {
+                "gene_id": ["ENSG1", "ENSG2"],
+                "paired": [3, 4],
+                "single": [1, 2],
+            })
+
+    def test_reads_mode_splits_mixed_layouts_before_featurecounts(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            single_reads = root / "single.fastq.gz"
+            paired_reads_1 = root / "paired_1.fastq.gz"
+            paired_reads_2 = root / "paired_2.fastq.gz"
+            for path in (single_reads, paired_reads_1, paired_reads_2):
+                path.write_bytes(b"reads")
+            (root / "run").mkdir()
+
+            samples = (
+                [{
+                    "sample_id": "single",
+                    "group": "control",
+                    "reads_1": [str(single_reads)],
+                    "reads_2": [],
+                    "count_matrix_column": "single",
+                    "accession": "single",
+                    "title": "single",
+                    "group_label": "control",
+                }],
+                [{
+                    "sample_id": "paired",
+                    "group": "treated",
+                    "reads_1": [str(paired_reads_1)],
+                    "reads_2": [str(paired_reads_2)],
+                    "count_matrix_column": "paired",
+                    "accession": "paired",
+                    "title": "paired",
+                    "group_label": "treated",
+                }],
+            )
+            featurecounts_calls = []
+
+            def fake_fastqc(**kwargs):
+                return {}, [], root / "stdout", root / "stderr"
+
+            def fake_fastp(**kwargs):
+                return kwargs["sample"], [], root / "stdout", root / "stderr"
+
+            def fake_star(**kwargs):
+                sample_id = kwargs["sample"]["sample_id"]
+                return root / f"{sample_id}.bam", [], root / "stdout", root / "stderr"
+
+            def fake_featurecounts(**kwargs):
+                featurecounts_calls.append(
+                    (kwargs["sample_order"], kwargs["paired_end"])
+                )
+                return root / "raw.tsv", [], root / "stdout", root / "stderr"
+
+            def fake_build_featurecounts_matrix(**kwargs):
+                sample_order = kwargs["sample_order"]
+                pd.DataFrame({
+                    "gene_id": ["ENSG1"],
+                    **{sample_id: [1] for sample_id in sample_order},
+                }).to_csv(kwargs["out_path"], sep="\t", index=False)
+                return kwargs["out_path"]
+
+            captured = {}
+
+            def fake_run_de_from_counts(**kwargs):
+                captured.update(kwargs)
+                return {"run_dir": str(root), "de_table_path": "output.tsv"}
+
+            with (
+                patch("funmirbench.experiments_pipeline.load_reads_samples", return_value=samples),
+                patch(
+                    "funmirbench.experiments_pipeline.prepare_reads_reference_assets",
+                    return_value={
+                        "star_index": root / "star",
+                        "gtf_path": root / "genes.gtf",
+                        "genome_fasta": str(root / "genome.fa"),
+                        "generated_star_index": False,
+                        "reused_star_index": True,
+                    },
+                ),
+                patch("funmirbench.experiments_pipeline.run_fastqc", side_effect=fake_fastqc),
+                patch("funmirbench.experiments_pipeline.run_fastp", side_effect=fake_fastp),
+                patch("funmirbench.experiments_pipeline.run_star_alignment", side_effect=fake_star),
+                patch("funmirbench.experiments_pipeline.run_featurecounts", side_effect=fake_featurecounts),
+                patch(
+                    "funmirbench.experiments_pipeline.build_featurecounts_matrix",
+                    side_effect=fake_build_featurecounts_matrix,
+                ),
+                patch(
+                    "funmirbench.experiments_pipeline.run_de_from_counts",
+                    side_effect=fake_run_de_from_counts,
+                ),
+            ):
+                run_reads_mode(
+                    {"dataset_id": "dataset", "source": {}},
+                    config_path=root / "config.yaml",
+                    repo=root,
+                    run_dir=root / "run",
+                    force=False,
+                )
+
+            self.assertEqual(
+                featurecounts_calls,
+                [(["single"], False), (["paired"], True)],
+            )
+            self.assertEqual(
+                list(captured["counts_df"].columns),
+                ["gene_id", "single", "paired"],
+            )
+            self.assertEqual(
+                captured["extra_manifest"]["library_layout"], "mixed"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_geo_download.py
+++ b/tests/test_geo_download.py
@@ -1,0 +1,75 @@
+import importlib
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+bio_module = types.ModuleType("Bio")
+bio_module.Entrez = types.SimpleNamespace()
+sys.modules.setdefault("Bio", bio_module)
+
+geo_download = importlib.import_module("pipelines.geo.geo_download")
+DEFAULT_GENOME_FASTA = geo_download.DEFAULT_GENOME_FASTA
+DEFAULT_GTF = geo_download.DEFAULT_GTF
+SRRInfo = geo_download.SRRInfo
+build_geo_sample_entries = geo_download.build_geo_sample_entries
+generate_yaml_config = geo_download.generate_yaml_config
+
+
+class GeoDownloadTests(unittest.TestCase):
+    def test_multiple_runs_remain_one_gsm_sample(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_directory = Path(temporary_directory)
+            runs = [
+                SRRInfo(srr="SRR2", gsm="GSM1", layout="PAIRED"),
+                SRRInfo(srr="SRR1", gsm="GSM1", layout="PAIRED"),
+            ]
+
+            control, treated = build_geo_sample_entries(
+                runs, ["GSM1"], [], output_directory
+            )
+
+            self.assertEqual(treated, [])
+            self.assertEqual(control, [{
+                "sample_id": "GSM1",
+                "reads_1": [
+                    str(output_directory / "SRR1_1.fastq.gz"),
+                    str(output_directory / "SRR2_1.fastq.gz"),
+                ],
+                "reads_2": [
+                    str(output_directory / "SRR1_2.fastq.gz"),
+                    str(output_directory / "SRR2_2.fastq.gz"),
+                ],
+            }])
+
+    def test_generated_config_preserves_multiple_run_paths(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_directory = Path(temporary_directory)
+            entry = {
+                "sample_id": "GSM1",
+                "reads_1": ["run1_1.fastq.gz", "run2_1.fastq.gz"],
+                "reads_2": ["run1_2.fastq.gz", "run2_2.fastq.gz"],
+            }
+            experiment = {
+                "id": "dataset",
+                "mirna": "hsa-miR-1-3p",
+                "experiment_type": "Overexpression",
+                "gse": "GSE1",
+            }
+
+            config_path = generate_yaml_config(
+                experiment, [entry], [dict(entry, sample_id="GSM2")], output_directory
+            )
+
+            config_text = config_path.read_text(encoding="utf-8")
+            self.assertIn("- run1_1.fastq.gz", config_text)
+            self.assertIn("- run2_2.fastq.gz", config_text)
+
+    def test_generated_configs_use_downloaded_ensembl_v115_references(self):
+        self.assertIn("ensembl_v115", DEFAULT_GENOME_FASTA)
+        self.assertIn("GRCh38.115.gtf.gz", DEFAULT_GTF)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Keep multiple SRR runs from one GSM as one biological sample and combine its run files before QC.
- Support comparisons containing both single-end and paired-end samples by counting each layout separately and combining the gene-count columns before DESeq2.
- Make generated configs and examples consistently use the Ensembl v115 reference installed by the repository downloader.
- Document the input format and add nine standard-library regression tests.

## Why

The experiments curated for BioGeMT/fun-miRBind#10 include four GSM samples with multiple technical runs and two comparisons with mixed library layouts. The current pipeline treats technical runs as separate replicates and rejects mixed layouts.

## Validation

`uv run python -m unittest discover -s tests` passes locally and from a fresh clone on node 4 (9 tests).
